### PR TITLE
Addition of k4unit testing package for KDB-X

### DIFF
--- a/k4unit/init.q
+++ b/k4unit/init.q
@@ -1,20 +1,14 @@
 / generic test script to be ran for individual packages
 
 \l k4unit/k4unit.q
-\l k4unit/mock.q
 
 packagetest:{[p]
-  // check if package is loaded 
-  //if[not (`$p) in key`.z.m;
-    //'"package is not loaded"];
 
-
-  / Check if package passed either by function variable or in command line 
+  / Load the Test CSv for the assocaited package 
+  / First line of the package will load the package using the following format 
+  / package:use`package 
   $[not ()~key tp:hsym `$p,"/test.csv";KUltf tp;'"no test csv"];
-  
-  
-  // Maintained logic of test helper script (not sure if we need to remove or not)
-  if[`test.q in key hsym`$p;system"l ",p,"/test.q"]; / Load any required helper code
+
   KUrt[];
   -1"Test results:";
   show KUTR;

--- a/k4unit/init.q
+++ b/k4unit/init.q
@@ -1,6 +1,6 @@
 / generic test script to be ran for individual packages
 
-\l k4unit/k4unit.q
+\l ::k4unit.q
 
 packagetest:{[p]
   / Load the Test CSv for the assocaited package 

--- a/k4unit/init.q
+++ b/k4unit/init.q
@@ -1,0 +1,27 @@
+/ generic test script to be ran for individual packages
+
+\l k4unit/k4unit.q
+\l k4unit/mock.q
+
+packagetest:{[p]
+  // check if package is loaded 
+  //if[not (`$p) in key`.z.m;
+    //'"package is not loaded"];
+
+
+  / Check if package passed either by function variable or in command line 
+  $[not ()~key tp:hsym `$p,"/test.csv";KUltf tp;'"no test csv"];
+  
+  
+  // Maintained logic of test helper script (not sure if we need to remove or not)
+  if[`test.q in key hsym`$p;system"l ",p,"/test.q"]; / Load any required helper code
+  KUrt[];
+  -1"Test results:";
+  show KUTR;
+  $[count failures:select from KUTR where not ok;
+    [-1"Test failures:";show failures];
+    -1"All tests passed"];
+  };
+  
+
+export:([packagetest:packagetest])

--- a/k4unit/init.q
+++ b/k4unit/init.q
@@ -17,8 +17,8 @@ packagetest:{[p]
   };
   
 / setter functions for config values
-verbose:{[x:`b]VERBOSE::x}
-debug:{[x:{$[x in 0 1 2;x;'"must be one of 0 1 2"]}]DEBUG::x}
+verbose:{[x:{$[x in 0 1 2;x;'"must be one of 0 1 2"]}]VERBOSE::x}
+debug:{[x:`b]DEBUG::x}
 delim:{[x:`c]DELIM::x}
 
 export:([packagetest:packagetest;verbose:verbose;debug:debug;delim:delim;saveresults:KUstr;loadresults:KUltr])

--- a/k4unit/init.q
+++ b/k4unit/init.q
@@ -3,11 +3,10 @@
 \l k4unit/k4unit.q
 
 packagetest:{[p]
-
   / Load the Test CSv for the assocaited package 
   / First line of the package will load the package using the following format 
   / package:use`package 
-  $[not ()~key tp:hsym `$p,"/test.csv";KUltf tp;'"no test csv"];
+  $[not ()~key tp:.Q.dd[hsym`$.Q.m.mp p;`test.csv];KUltf tp;'"no test csv"];
 
   KUrt[];
   -1"Test results:";
@@ -17,5 +16,9 @@ packagetest:{[p]
     -1"All tests passed"];
   };
   
+/ setter functions for config values
+verbose:{[x:`b]VERBOSE::x}
+debug:{[x:{$[x in 0 1 2;x;'"must be one of 0 1 2"]}]DEBUG::x}
+delim:{[x:`c]DELIM::x}
 
-export:([packagetest:packagetest])
+export:([packagetest:packagetest;verbose:verbose;debug:debug;delim:delim;saveresults:KUstr;loadresults:KUltr])

--- a/k4unit/k4unit.md
+++ b/k4unit/k4unit.md
@@ -8,20 +8,68 @@ Includes a module that is used for testing another package
 Navigate to root project directory (kdbx-packages)
 
 Run the KDB-X q session and then load the k4unit package. 
-```bash
-k4unit:use`k4unit
-
+```q
+q)k4unit:use`k4unit
 ```
 
 Then run the package test function to run the tests on another package, example:
-```bash
-k4unit.packagetest"timezone"
-
+```q
+q)k4unit.packagetest`timezone
 ```
 
 As part of the test cases it rquires the "before" test to module load the package with the same naming convention used for the tests, in this case "timezone":
-```bash 
+``` 
 before,0,0,q,timezone:use`timezone,1,,Initialize package
 true,0,0,q,2025.07.22D14:19:48.386221575=timezone.localtogmt[`$"America/New_York";2025.07.22D10:19:48.386221575],1,,Test local to gmt 1
+```
 
 ---
+
+### Saving & loading results
+
+Results can be saved & loaded from CSV (default delimiter `,` can be changed, see
+Configuration section) using following functions:
+
+```q
+/ save currently stored results
+q)k4unit.saveresults`:path/to/output.csv
+```
+
+```q
+/ load previously stored results
+q)k4unit.loadresults`:path/to/output.csv
+action ms bytes lang code                                                                                                                                                          ..
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------..
+true   0  0     q    2025.07.22D14:19:48.386221575=timezone.localtogmt[`$"America/New_York";2025.07.22D10:19:48.386221575]                                                         ..
+true   0  0     q    1999.03.03D12:13:48.919241092=timezone.localtogmt[`$"Europe/London";1999.03.03D12:13:48.919241092]                                                            ..
+true   0  0     q    1967.05.02D21:03:52.857237462=timezone.gmttolocal[`$"America/Toronto";1967.05.03D01:03:52.857237462]                                                          ..
+true   0  0     q    2017.09.01D04:03:52.857237462=timezone.gmttolocal[`$"America/Los_Angeles";2017.09.01D11:03:52.857237462]                                                      ..
+true   0  0     q    2025.07.21D19:19:48.386221575=timezone.convert[`$"Asia/Singapore";`$"America/Vancouver";2025.07.22D10:19:48.386221575]                                        ..
+true   0  0     q    2025.07.24D15:27:58.224707599=timezone.convert[`$"America/New_York";`$"America/Toronto";2025.07.24D15:27:58.224707599]                                        ..
+true   0  0     q    2025.11.02D01:30:00.000=timezone.convert[`$"America/New_York";`$"America/New_York";2025.11.02D01:30:00.000]                                                   ..
+true   0  0     q    (2025.08.03D22:50:46.515073740;2025.08.04D22:50:46.515073740;2025.08.05D22:50:46.515073740)~timezone.localtogmt[`$"America/Toronto";(2025.08.03D18:50:46.51507..
+true   0  0     q    (2025.08.03D11:50:46.515073740;2025.08.04D11:50:46.515073740;2025.08.05D11:50:46.515073740)~timezone.gmttolocal[`$"America/Vancouver";(2025.08.03D18:50:46.515..
+true   0  0     q    (2025.08.05D19:50:46.515073740;2025.08.05D14:50:46.515073740)~timezone.gmttolocal[`$("Europe/London";"America/New_York");2# 2025.08.05D18:50:46.515073740]    ..
+true   0  0     q    (2025.08.05D17:50:46.515073740;2025.08.05D22:50:46.515073740)~timezone.localtogmt[`$("Europe/London";"America/New_York");2# 2025.08.05D18:50:46.515073740]    ..
+true   0  0     q    `notValidTimezone~.[timezone.gmttolocal;(`testTimezone;.z.p);{`$x}]                                                                                           ..
+true   0  0     q    `notValidTimezone~.[timezone.localtogmt;(`testTimezone;.z.p);{`$x}]           
+```
+
+### Configuration
+
+There are 3 functions provided for configuring k4unit.
+
+```q
+/ set debug level, can be 0, 1 or 2. Default = 0
+q)k4unit.debug 0
+```
+
+```q
+/ set verbose mode on/off, can be 0b or 1b. Default = 1b
+q)k4unit.verbose 0b
+```
+
+```q
+/ set delimiter for saving/loading results, must be passed as a char. Default = ,
+q)k4unit.delim "|"
+```

--- a/k4unit/k4unit.md
+++ b/k4unit/k4unit.md
@@ -70,6 +70,6 @@ q)k4unit.verbose 0
 ```
 
 ```q
-/ set delimiter for saving/loading results, must be passed as a char. Default = ,
+/ set delimiter for saving/loading results and test CSVs, must be passed as a char. Default = ,
 q)k4unit.delim "|"
 ```

--- a/k4unit/k4unit.md
+++ b/k4unit/k4unit.md
@@ -60,13 +60,13 @@ true   0  0     q    `notValidTimezone~.[timezone.localtogmt;(`testTimezone;.z.p
 There are 3 functions provided for configuring k4unit.
 
 ```q
-/ set debug level, can be 0, 1 or 2. Default = 0
-q)k4unit.debug 0
+/ set debug on/off, can be 0b or 1b. Default = 0b
+q)k4unit.debug 1b
 ```
 
 ```q
-/ set verbose mode on/off, can be 0b or 1b. Default = 1b
-q)k4unit.verbose 0b
+/ set verbose mode, can be 0 (no logging to console), 1 (log filenames) or 2 (log tests). Default = 1
+q)k4unit.verbose 0
 ```
 
 ```q

--- a/k4unit/k4unit.md
+++ b/k4unit/k4unit.md
@@ -1,0 +1,27 @@
+## KDB-X Package Testing Framework 
+
+Includes a module that is used for testing another package
+
+---
+
+### To Use: 
+Navigate to root project directory (kdbx-packages)
+
+Run the KDB-X q session and then load the k4unit package. 
+```bash
+k4unit:use`k4unit
+
+```
+
+Then run the package test function to run the tests on another package, example:
+```bash
+k4unit.packagetest"timezone"
+
+```
+
+As part of the test cases it rquires the "before" test to module load the package with the same naming convention used for the tests, in this case "timezone":
+```bash 
+before,0,0,q,timezone:use`timezone,1,,Initialize package
+true,0,0,q,2025.07.22D14:19:48.386221575=timezone.localtogmt[`$"America/New_York";2025.07.22D10:19:48.386221575],1,,Test local to gmt 1
+
+---

--- a/k4unit/k4unit.q
+++ b/k4unit/k4unit.q
@@ -1,0 +1,139 @@
+/ k4 unit testing, loads tests from csv's, runs+logs to database
+/ csv columns: action,ms,bytes,lang,code (csv with colheaders)
+/ if your code contains commas enclose the whole code in "quotes"
+/ usage: q k4unit.q -p 5001
+/ KUT <-> KUnit Tests
+KUT:([]action:`symbol$();ms:`int$();bytes:`long$();lang:`symbol$();code:`symbol$();repeat:`int$();minver:`float$();file:`symbol$();comment:())
+/ KUltd `:dirname and/or KUltf `:filename.csv
+/ KUrt[] / run tests
+/ KUTR <-> KUnit Test Results
+/ KUrtf`:filename.csv / refresh expected <ms> and <bytes> based on observed results in KUTR
+KUTR:([]action:`symbol$();ms:`int$();bytes:`long$();lang:`symbol$();code:`symbol$();repeat:`int$();file:`symbol$();msx:`int$();bytesx:`long$();ok:`boolean$();okms:`boolean$();okbytes:`boolean$();valid:`boolean$();timestamp:`datetime$())
+/ look at KUTR in browser or q session
+/ select from KUTR where not ok // KUerr
+/ select from KUTR where not okms // KUslow
+/ select count i by ok,okms,action from KUTR
+/ select count i by ok,okms,action,file from KUTR
+/ KUstr[] / save test results 
+/ KUltr[] / reload previously saved test results
+/ action:	
+/ 	`beforeany - onetime, run before any tests
+/		`beforeeach - run code before tests in every file
+/			`before - run code before tests in this file ONLY
+/			`run - run code, check execution time against ms
+/			`true - run code, check if returns true(1b)
+/			`fail - run code, it should fail (2+`two)
+/			`after - run code after tests in this file ONLY
+/		`aftereach - run code after tests in each file
+/ 	`afterall - onetime, run code after all tests, use for cleanup/finalise
+/ lang: k or q (or s if you really feel you must..), default q
+/ code: code to be executed
+/ repeat: number of repetitions (do[repeat;code]..), default 1
+/ ms: max milliseconds it should take to run, 0 => ignore
+/ bytes: bytes it should take to run, 0 => ignore
+/ minver: minimum version of kdb+ (.z.K)
+/ file: filename
+/ action,ms,bytes,lang,code,file: from KUT
+/ msx: milliseconds taken to eXecute code
+/ bytesx: bytes used to eXecute code 
+/ ok: true if the test completes correctly (note: its correct for a fail task to fail)
+/ okms: true if msx is not greater than ms, ie if performance is ok
+/ okbytes: true if bytesx is not greater than bytes, ie if memory usage is ok
+/ valid: true if the code is valid (ie doesn't crash - note: `fail code is valid if it fails)
+/ timestamp: when test was run
+/ comment: description of the test if it's obscure.. 
+
+if[not"B"$first getenv`K4UNIT_FIX_CONSOLE_SIZE;system"c 10000 10000"];
+KUstr:{.KU.SAVEFILE 0:.KU.DELIM 0:update code:string code from KUTR} / save test results
+KUltr:{`KUTR upsert("SIJSSIJSIBBBBZ";enlist .KU.DELIM)0:.KU.SAVEFILE} / reload previously saved test results 
+
+KUltf:{ / (load test file) - load tests in csv file <x> into KUT
+	before:count KUT;
+	this:update file:x,action:lower action,lang:`q^lower lang,code:`$code,ms:0^ms,bytes:0j^bytes,repeat:1|repeat,minver:0^minver from `action`ms`bytes`lang`code`repeat`minver`comment xcol("SIJS*IF*";enlist .KU.DELIM)0:x:hsym x;
+	KUT,:select from this where minver<=.z.K;
+	/KUT,:update file:x,action:lower action,lang:`q^lower lang,ms:0^ms,bytes:0j,repeat:1|repeat from `action`ms`lang`code`repeat`comment xcol("SISSI*";enlist .KU.DELIM)0:x:hsym x;
+	neg before-count KUT}
+
+KUltd:{ / (load test dir) - load all *.csv files in directory <x> into KUT
+	before:count KUT;
+	files:(` sv)each(x,'key x);KUltf each files where(lower files)like"*.csv";
+	neg before-count KUT}                   
+
+KUrt:{ / (run tests) - run contents of KUT, save results to KUTR
+	before:count KUTR;uf:exec asc distinct file from KUT;i:0;
+	if[.KU.VERBOSE;-1(string .z.Z)," start"];
+	exec .z.m.KUexec'[lang;code;repeat] from KUT where action=`beforeany;
+	do[count uf;
+		ufi:uf[i];KUTI:select from KUT where file=ufi;
+		if[.KU.VERBOSE;
+			-1(string .z.Z)," ",(string ufi)," ",(string exec count i from KUTI where action in `run`true`fail)," test(s)"];
+		exec .z.m.KUexec'[lang;code;repeat] from KUT where action=`beforeeach;
+		exec .z.m.KUexec'[lang;code;repeat] from KUTI where action=`before;
+		/ preserve run,true,fail order
+		exec .z.m.KUact'[action;lang;code;repeat;ms;bytes;file]from KUTI where action in`true`fail`run;
+		exec .z.m.KUexec'[lang;code;repeat] from KUTI where action=`after;
+		exec .z.m.KUexec'[lang;code;repeat] from KUT where action=`aftereach;
+		i+:1];
+	exec .z.m.KUexec'[lang;code;repeat] from KUT where action=`afterall;
+	if[.KU.VERBOSE;-1(string .z.Z)," end"];
+	neg before-count KUTR}
+
+KUpexec:{[prefix;lang;code;repeat;allowfail] 
+	s:prefix,(string lang),")",$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"];
+	if[1<.KU.VERBOSE;-1 s];$[.KU.DEBUG&allowfail;value s;@[value;s;`FA1L]]}
+
+KUfailed:{`FA1L~x}
+
+KUexec:{[lang;code;repeat]
+	value(string lang),")",$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"]}
+
+KUact:{[action;lang;code;repeat;ms;bytes;file]
+	msx:0;bytesx:0j;ok:okms:okbytes:valid:0b;
+	if[action=`run;
+		failed:KUfailed r:KUpexec["\\ts ";lang;code;repeat;1b];msx:`int$$[failed;0;r 0];bytesx:`long$$[failed;0;r 1];
+		ok:not failed;okms:$[ms;not msx>ms;1b];okbytes:$[bytes;not bytesx>bytes;1b];valid:not failed];
+	if[action=`true;
+		failed:KUfailed r:KUpexec["";lang;code;repeat;1b];
+		ok:$[failed;0b;r~1b];okms:okbytes:1b;valid:not failed];
+	if[action=`fail;
+		failed:KUfailed r:KUpexec["";lang;code;repeat;0b];
+		ok:failed;okms:okbytes:valid:1b];
+	`.m.k4unit.KUTR insert(action;ms;bytes;lang;code;repeat;file;msx;bytesx;ok;okms;okbytes;valid;.z.Z);
+	}
+	
+KUrtf:{ / (refresh test file) updates test file x with realistic <ms>/<bytes>/<repeat> based on seen values of msx/bytesx from KUTR
+	if[not x in exec file from KUTR;'"no test results found"];
+	/x 0:.KU.DELIM 0:select action,ms,lang,string code,repeat,comment from((`code xkey KUT)upsert select code,ms:floor 1.25*msx from KUTR)where file=x}
+	kut:`code xkey select from KUT where file=x;kutr:select from KUTR where file=x,action=`run;
+	kutr:update repeat:1,ms:floor 1.5*msx%repeat from kutr where 75<ms%repeat;
+	kutr:update repeat:500000&floor repeat*50%1|msx,ms:75 from kutr where 75>=ms%repeat;
+	kutr:update bytes:`long$floor 1.5*bytesx from kutr;
+	x 0:.KU.DELIM 0:select action,ms,bytes,lang,string code,repeat,minver,comment from kut upsert select code,ms,bytes,repeat from kutr} 
+
+KUf::distinct exec file from KUTR / fristance: KUrtf each KUf
+KUslow::delete okms from select from KUTR where not okms
+KUslowf::distinct exec file from KUslow
+KUbig::delete okbytes from select from KUTR where not okbytes
+KUbigf::distinct exec file from KUbig
+KUerr::delete ok from select from KUTR where not ok
+KUerrf::distinct exec file from KUerr
+KUinvalid::delete ok,valid from select from KUTR where not valid
+KUinvalidf::distinct exec file from KUinvalid
+
+\d .KU
+/ VERBOSE:
+/ 0 - no logging to console
+/ 1 - log filenames
+/>1 - log tests
+VERBOSE:1
+/ DEBUG:
+/0 - trap errors, press on regardless
+/1 - suspend if errors (except if action=`fail of course)
+DEBUG:0
+/ DELIM, csv delimiter
+DELIM:","
+/ Test Results SAVEFILE
+SAVEFILE:`:KUTR.csv
+
+\d .
+@[value;"\\l k4unit.custom.q";::];      

--- a/timezone/test.csv
+++ b/timezone/test.csv
@@ -1,20 +1,18 @@
 action,ms,bytes,lang,code,repeat,minver,comment
-before,0,0,q,.timezone.init[],1,,Initialize package
-true,0,0,q,0<count .timezone.offsets,1,,Confirm tzinfo is read in properly
-true,0,0,q,400<count .timezone.zones,1,,Confirm distinct time zones is populated and significant number available
+before,0,0,q,timezone:use`timezone,1,,Initialize package
 
-true,0,0,q,2025.07.22D14:19:48.386221575=.timezone.localtogmt[`$"America/New_York";2025.07.22D10:19:48.386221575],1,,Test local to gmt 1
-true,0,0,q,1999.03.03D12:13:48.919241092=.timezone.localtogmt[`$"Europe/London";1999.03.03D12:13:48.919241092],1,,Test local to gmt 2
-true,0,0,q,1967.05.02D21:03:52.857237462=.timezone.gmttolocal[`$"America/Toronto";1967.05.03D01:03:52.857237462],1,,Test gmt to local 1
-true,0,0,q,2017.09.01D04:03:52.857237462=.timezone.gmttolocal[`$"America/Los_Angeles";2017.09.01D11:03:52.857237462],1,,Test gmt to local 2
-true,0,0,q,2025.07.21D19:19:48.386221575=.timezone.convert[`$"Asia/Singapore";`$"America/Vancouver";2025.07.22D10:19:48.386221575],1,,Test timezone to timezone 1
-true,0,0,q,2025.07.24D15:27:58.224707599=.timezone.convert[`$"America/New_York";`$"America/Toronto";2025.07.24D15:27:58.224707599],1,,Test timezone to timezone 2
-true,0,0,q,2025.11.02D01:30:00.000=.timezone.convert[`$"America/New_York";`$"America/New_York";2025.11.02D01:30:00.000],1,,DST edge case
+true,0,0,q,2025.07.22D14:19:48.386221575=timezone.localtogmt[`$"America/New_York";2025.07.22D10:19:48.386221575],1,,Test local to gmt 1
+true,0,0,q,1999.03.03D12:13:48.919241092=timezone.localtogmt[`$"Europe/London";1999.03.03D12:13:48.919241092],1,,Test local to gmt 2
+true,0,0,q,1967.05.02D21:03:52.857237462=timezone.gmttolocal[`$"America/Toronto";1967.05.03D01:03:52.857237462],1,,Test gmt to local 1
+true,0,0,q,2017.09.01D04:03:52.857237462=timezone.gmttolocal[`$"America/Los_Angeles";2017.09.01D11:03:52.857237462],1,,Test gmt to local 2
+true,0,0,q,2025.07.21D19:19:48.386221575=timezone.convert[`$"Asia/Singapore";`$"America/Vancouver";2025.07.22D10:19:48.386221575],1,,Test timezone to timezone 1
+true,0,0,q,2025.07.24D15:27:58.224707599=timezone.convert[`$"America/New_York";`$"America/Toronto";2025.07.24D15:27:58.224707599],1,,Test timezone to timezone 2
+true,0,0,q,2025.11.02D01:30:00.000=timezone.convert[`$"America/New_York";`$"America/New_York";2025.11.02D01:30:00.000],1,,DST edge case
 
-true,0,0,q,(2025.08.03D22:50:46.515073740;2025.08.04D22:50:46.515073740;2025.08.05D22:50:46.515073740)~.timezone.localtogmt[`$"America/Toronto";(2025.08.03D18:50:46.515073740;2025.08.04D18:50:46.515073740;2025.08.05D18:50:46.515073740)],1,,Test single timezone multi ts 1
-true,0,0,q,(2025.08.03D11:50:46.515073740;2025.08.04D11:50:46.515073740;2025.08.05D11:50:46.515073740)~.timezone.gmttolocal[`$"America/Vancouver";(2025.08.03D18:50:46.515073740;2025.08.04D18:50:46.515073740;2025.08.05D18:50:46.515073740)],1,,Test single timezone multi ts 2
-true,0,0,q,(2025.08.05D19:50:46.515073740;2025.08.05D14:50:46.515073740)~.timezone.gmttolocal[`$("Europe/London";"America/New_York");2# 2025.08.05D18:50:46.515073740],1,,Test multi timezones multi ts 1
-true,0,0,q,(2025.08.05D17:50:46.515073740;2025.08.05D22:50:46.515073740)~.timezone.localtogmt[`$("Europe/London";"America/New_York");2# 2025.08.05D18:50:46.515073740],1,,Test multi timezones multi ts 2
+true,0,0,q,(2025.08.03D22:50:46.515073740;2025.08.04D22:50:46.515073740;2025.08.05D22:50:46.515073740)~timezone.localtogmt[`$"America/Toronto";(2025.08.03D18:50:46.515073740;2025.08.04D18:50:46.515073740;2025.08.05D18:50:46.515073740)],1,,Test single timezone multi ts 1
+true,0,0,q,(2025.08.03D11:50:46.515073740;2025.08.04D11:50:46.515073740;2025.08.05D11:50:46.515073740)~timezone.gmttolocal[`$"America/Vancouver";(2025.08.03D18:50:46.515073740;2025.08.04D18:50:46.515073740;2025.08.05D18:50:46.515073740)],1,,Test single timezone multi ts 2
+true,0,0,q,(2025.08.05D19:50:46.515073740;2025.08.05D14:50:46.515073740)~timezone.gmttolocal[`$("Europe/London";"America/New_York");2# 2025.08.05D18:50:46.515073740],1,,Test multi timezones multi ts 1
+true,0,0,q,(2025.08.05D17:50:46.515073740;2025.08.05D22:50:46.515073740)~timezone.localtogmt[`$("Europe/London";"America/New_York");2# 2025.08.05D18:50:46.515073740],1,,Test multi timezones multi ts 2
 
-true,0,0,q,`notValidTimezone~.[.timezone.gmttolocal;(`testTimezone;.z.p);{`$x}],1,,Test error catch for invalid timezone 1
-true,0,0,q,`notValidTimezone~.[.timezone.localtogmt;(`testTimezone;.z.p);{`$x}],1,,Test error catch for invalid timezone 2
+true,0,0,q,`notValidTimezone~.[timezone.gmttolocal;(`testTimezone;.z.p);{`$x}],1,,Test error catch for invalid timezone 1
+true,0,0,q,`notValidTimezone~.[timezone.localtogmt;(`testTimezone;.z.p);{`$x}],1,,Test error catch for invalid timezone 2


### PR DESCRIPTION
Addition of 4kunit testing package:

Usage:
q)testing:use`k4unit

q)testing.packagetest"timezone"

Preqrequisites:

- Testing CSV inside the package: (timezone/test.csv)

- Inside the test csv, the before step must load the package: 
>before,0,0,q,timezone:use`timezone,1,,Initialize package
- The commands inside the test csv must be consistent with the naming of the package in the before step (timezone in above example):
 
>true,0,0,q,2025.07.22D14:19:48.386221575=timezone.localtogmt[`$"America/New_York";2025.07.22D10:19:48.386221575],1,,Test local to gmt 1