### PR TITLE
analytics: add ffill (+runnable example) -k4unit tests to follow

### DIFF
--- a/analytics/analytics.q
+++ b/analytics/analytics.q
@@ -1,0 +1,35 @@
+/ library for some common use analytic functions
+
+
+.anl.ffill:{[arg]
+  :$[98h=type arg;.anl.filltable[arg];
+    99h=type arg;.anl.filldict[arg];
+   '"Input parameter must be a dictionary with keys-table, keycols, by or a table to fill "]
+   };
+
+
+/ fill whole table, straight copy of previous values
+.anl.filltable:{[t] :fills t;};
+
+.anl.filldict:{[d] 
+   / fill table based on provided criterion, by and keycols
+    table:d[`table];
+    headers:cols table;   
+    kcols:d[`keycols],();
+    if[2<count key d; 
+       :![table;();(enlist d`by)!(enlist d`by);kcols!((^\;) each kcols)]];
+     / q-sql:update fills kcols by col from table
+    if[`keycols in key d;
+       :![table;();0b;kcols!((^\;) each kcols)]];
+     / q-sql: update fills keycols1 [,fills keycols2...] from table
+    if[`by in key d;          
+       :![table;();(enlist d`by)!(enlist d`by);hd!((^\;) each hd:headers where (any null table@) each headers)]];
+     / q-sql:update fills null_cols by col from table
+     };
+    
+
+.anl.ffillzero:{[d]
+   / replace zeros in specified columns with previous values
+    d[`table]:@[d[`table];d[`keycols];{?[0=x;0n;x]}];
+    :.anl.filldict[d];
+    };

--- a/analytics/examples/analytics_ffill_example.q
+++ b/analytics/examples/analytics_ffill_example.q
@@ -1,0 +1,92 @@
+
+/ analytics/examples/ffill_example.q
+/ run from repo root:
+\l analytics/analytics.q
+
+
+
+
+n:30;
+prob:0.2;
+
+genull:{
+  / generate table with random missing values (null)
+    t:([]time:n?.z.P;sym:n?`AMD`AAPL`MSFT`IBM;ask:n?100f;bid:n?100f;asize:n?500i;bsize:n?500i;ex:n?`NYSE`CME`LSE);
+    t:`time`sym xasc t;
+    t:update ask:?[prob>n?1f;0n;ask] from t;
+    t:update bid:?[prob>n?1f;0n;bid] from t;
+    t:update asize:?[prob>n?1f;0n;asize] from t;
+    t:update bsize:?[prob>n?1f;0n;bsize] from t;
+    t:update ex:?[prob>n?1f;`;ex] from t;
+    :t
+    };
+
+
+genzero:{
+  / generate table with random 0 values
+  t:([]time:n?.z.P;sym:n?`AMD`AAPL`MSFT`IBM;ask:n?100f;bid:n?100f;asize:n?500i;bsize:n?500i;ex:n?`NYSE`CME`LSE);
+  t:`time`sym xasc t;
+  t:update ask:?[prob>n?1f;0;ask] from t;
+  t:update bid:?[prob>n?1f;0;bid] from t;
+  t:update asize:?[prob>n?1f;0;asize] from t;
+  :t
+  };
+
+
+
+table:genull[];
+
+/ case 1:
+-1 "fill on table";
+filledtable:.anl.ffill table;
+
+
+/ case 2:
+-1 "fill on dictionary with arg: by=sym; key=(ask,asize,bsize):";
+args:(`table`by`keycols)!(table;`sym;`ask`asize`bsize);
+filledtable:.anl.ffill args;
+
+
+/ case 3:
+-1 "fill on dictionary with arg: by=sym; key=ex:";
+args:(`table`by`keycols)!(table;`sym;`ex);
+filledtable:.anl.ffill args;
+
+
+
+/ case 4:
+-1 "fill on dictionary with arg: by=sym:";
+args:(`table`by)!(table;`sym);
+filledtable:.anl.ffill args;
+
+
+/ case 5:
+-1 "fill on dictionary with arg: keycols=ask:";
+args:(`table`keycols)!(table;`ask);
+filledtable:.anl.ffill args;
+
+
+/ case 6:
+-1 "fill on dictionary with arg: keycols=(ask,bid,asize):";
+args:(`table`keycols)!(table;`ask`bid`asize);
+filledtable:.anl.ffill args;
+
+
+table:genzero[];
+
+
+/ case 7:
+-1 "fill on dictionary with arg: by=sym, keycols=(ask,bid):";
+args:(`table`by`keycols)!(table;`sym;`ask`bid);
+filledtable:.anl.ffillzero args;
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
What
- Implement ffill in analytics.
- Add a runnable example at analytics/examples/ffill_example.q

Why
- Small, reviewable first slice before adding k4unit tests/docs.

Style question
- Implemented using q-SQL functional form. If it is not the best implementation, I’ll rewrite accordingly.

Next
- Add k4unit tests and a brief README section once style is agreed.
