### PR TITLE
Update tests to allow for test reruns

### DIFF
--- a/di/pubsub/test.csv
+++ b/di/pubsub/test.csv
@@ -1,13 +1,13 @@
 action,ms,bytes,lang,code,repeat,minver,comment
 comment,,,,,,,Setup for server and client testing
 comment,,,,,,,Replace $QHOME (defaults to $HOME) to avoid hard-coding
-beforeany,0,0,q,system"q -p 5010 -q &",1,,start server in background
-beforeany,0,0,q,system"sleep 1",1,,wait for server to initialize
-beforeany,0,0,q,h:hopen`::5010,1,,open handle h on client for testing
-beforeany,0,0,q,h"pubsub:use`di.pubsub",,initialize pubsub package
+run,0,0,q,system"q -p 5010 -q &",1,,start server in background
+run,0,0,q,system"sleep 1",1,,wait for server to initialize
+run,0,0,q,h:hopen`::5010,1,,open handle h on client for testing
+run,0,0,q,h"pubsub:use`di.pubsub",,initialize pubsub package
 true,0,0,q,h>0,1,,verify client connected to server
-beforeany,0,0,q,h"trade:([]time:\"p\"$();`g#sym:`$();price:\"f\"$();tsize:\"i\"$());",1,,define trade table on server
-beforeany,0,0,q,h"quote:([]time:\"p\"$();`g#sym:`$();bid:\"f\"$();bidsize:\"i\"$();ask:\"f\"$();asksize:\"i\"$());",1,,define quote table on server
+run,0,0,q,h"trade:([]time:\"p\"$();`g#sym:`$();price:\"f\"$();tsize:\"i\"$());",1,,define trade table on server
+run,0,0,q,h"quote:([]time:\"p\"$();`g#sym:`$();bid:\"f\"$();bidsize:\"i\"$();ask:\"f\"$();asksize:\"i\"$());",1,,define quote table on server
 run,0,0,q,h".m.di.0pubsub.init[]",,
 true,0,0,q,1b~h".m.di.0pubsub.initialized",1,,confirm server initialized with necessary data
 run,0,0,q,clt:first h"key[.z.W]",1,,get client handle on server
@@ -112,3 +112,6 @@ true,0,0,q,98h~type first res[1],1,,client receives table schema
 run,0,0,q,res:h"select from .m.di.0pubsub.reqfilteredtbl where table=`quote",1,,check filtered table for the subscription
 run,0,0,q,res:select from res where handle=clt,1,,check filtered table for the subscription
 true,0,0,q,res[`filts][0]~enlist enlist(>;`bid;50f),1,, test symbols are listed under filters
+
+run,0,0,q,neg[h](exit;0),1,,close handle
+run,0,0,q,hclose h,1,,

--- a/di/pubsub/test.csv
+++ b/di/pubsub/test.csv
@@ -113,5 +113,5 @@ run,0,0,q,res:h"select from .m.di.0pubsub.reqfilteredtbl where table=`quote",1,,
 run,0,0,q,res:select from res where handle=clt,1,,check filtered table for the subscription
 true,0,0,q,res[`filts][0]~enlist enlist(>;`bid;50f),1,, test symbols are listed under filters
 
-run,0,0,q,neg[h](exit;0),1,,close background process
+run,0,0,q,neg[h](exit;0);neg[h](::),1,,close background process and flush
 run,0,0,q,hclose h,1,,close handle

--- a/di/pubsub/test.csv
+++ b/di/pubsub/test.csv
@@ -113,5 +113,5 @@ run,0,0,q,res:h"select from .m.di.0pubsub.reqfilteredtbl where table=`quote",1,,
 run,0,0,q,res:select from res where handle=clt,1,,check filtered table for the subscription
 true,0,0,q,res[`filts][0]~enlist enlist(>;`bid;50f),1,, test symbols are listed under filters
 
-run,0,0,q,neg[h](exit;0),1,,close handle
-run,0,0,q,hclose h,1,,
+run,0,0,q,neg[h](exit;0),1,,close background process
+run,0,0,q,hclose h,1,,close handle

--- a/di/timer/test.csv
+++ b/di/timer/test.csv
@@ -6,6 +6,8 @@ before,0,0,q,.m.di.0timer.debug:0b,1,,Set debug for testing
 before,0,0,q,.m.di.0timer.logcall:1b,1,,Set logcall for testing
 before,0,0,q,.m.di.0timer.cycletime:100,1,,Set cycletime for testing
 
+run,0,0,q,timer.deletejobs key[.m.di.0timer.jobs]`id,1,,Clear jobs table in case of test rerun
+
 run,0,0,q,timer.addjob.custom[`testcustom1;{};();10;1;(enlist `maxruns)!(enlist 3)],1,,Add job for custom 1
 true,0,0,q,`testcustom1 in key .m.di.0timer.jobs,1,,Test job in table for custom 1
 true,0,0,q,.m.di.0timer.jobs[`testcustom1][`maxruns]=3,1,,Test option overwrite for custom 1
@@ -81,4 +83,3 @@ true,0,0,q,.test.exec2,1,,Test run succeeded for exec 2
 run,0,0,q,testexec3:{.test.exec3:x+y};timer.addjob.default[`testexec3;`testexec3;(2;3);10;1],1,,Add job for exec 3
 run,0,0,q,.m.di.0timer.runandschedule[`testexec3],1,,Test timer function exec 3
 true,0,0,q,.test.exec3=5,1,,Test run succeeded for exec 3
-

--- a/di/usage/test.csv
+++ b/di/usage/test.csv
@@ -148,5 +148,3 @@ run,0,0,q,.test.clearusage[],1,1,
 
 run,0,0,q,usage.init[(enlist `test)!enlist 1b],1,1,pass a non config var to init
 fail,0,0,q,key .m.di.0usage.test,1,1,
-
-run,0,0,q,rerun:1b,1,,

--- a/di/usage/test.csv
+++ b/di/usage/test.csv
@@ -7,6 +7,7 @@ before,0,0,q,.test.clearusage:{.m.di.0usage.usage:0#.m.di.0usage.usage},1,1,func
 
 before,0,0,q,.test.handlers: (`pw`po`pc`wo`wc`ws`pg`ps`ph`pp`exit),1,1,modified handlers
 before,0,0,q,.test.customtracker:([]zcmd:`symbol$(); args:()),1,1,table to track custom handlers arguments
+before,0,0,q,.test.resetcustomtracker:{.test.customtracker:0#.test.customtracker},1,1,function to clear customtracker table
 before,0,0,q,.test.setcustomhandler:{[handler]handler set {[zcmd;args] `.test.customtracker upsert (zcmd;args)}[handler;];},1,1,funtion to apply custom functionality to handlers
 before,0,0,q,.test.custompasshandler:{[handler]handler set {[zcmd;user;pass] `.test.customtracker upsert (zcmd;(user;pass))}[handler;;];},1,1,funtion to apply custom .z.pw handler
 
@@ -27,6 +28,7 @@ true,0,0,q,(count .test.handlers) = count select distinct zcmd from usage.getusa
 run,0,0,q,.test.resethandlers[],1,1,restore default handles
 run,0,0,q,.test.clearusage[],1,1,clear usage table
 
+run,0,0,q,.test.resetcustomtracker[],1,1,clear custom tracker in case of test rerun
 run,0,0,q,.test.setcustomhandler each .Q.dd[`.z] each .test.handlers,1,1,run with custom handlers and verify that they are wrapped and properly invoked after running usage.init
 run,0,0,q,.test.custompasshandler `.z.pw,1,1,
 run,0,0,q,usage.init[],1,1,initialize usage to wrap custom handlers
@@ -107,6 +109,7 @@ run,0,0,q,.test.resethandlers[],1,1,restore default handles
 run,0,0,q,.test.clearusage[],1,1,default value
 
 run,0,0,q,usage.init[],1,1,test extension functionality
+run,0,0,q,.test.ext:(),1,1,set to be empty in case of test rerun
 run,0,0,q,"usage.setextension[{.test.ext,:enlist x}]",1,1,
 run,0,0,q,.z.pw[`test_user;"pass123"],1,1,run args against each handle
 run,0,0,q,.z.po 1i,1,1,
@@ -145,3 +148,5 @@ run,0,0,q,.test.clearusage[],1,1,
 
 run,0,0,q,usage.init[(enlist `test)!enlist 1b],1,1,pass a non config var to init
 fail,0,0,q,key .m.di.0usage.test,1,1,
+
+run,0,0,q,rerun:1b,1,,


### PR DESCRIPTION
Currently the tests work on the first pass, but rerunning in the same process sometimes leads to fails or the code erroring. I've made some changes here to clean up the tests to allow for rerunning in the same process without errors. 3 packages were affected:

 - **pubsub**: this was erroring on subsequent runs, I determined this is because the ports being opened were being ran as a `beforeany` which had a weird interaction on second runs. changing this to just `run` seems to allow all the tests to pass again, but with the caveat that I get the two error outputs whilst running:
 ```
'2025.10.29T14:18:05.504 5010. OS reports: Address already in use
'2025.10.29T14:18:06.521 5010. OS reports: Address already in use
```
 - **timer**: this package was relatively simple to clean up, the `jobs`table just needed emptying before being ran again. This was easy enough to accomplish by just utilising `timer.deletejobs` to empty any ids.
 - **usage**: Similarly to timer, this was simple enough to fix by adding some rows to reset some variables or empty some tables