### PR TITLE
TorQ email modularization

### DIFF
--- a/di/email/email.md
+++ b/di/email/email.md
@@ -1,0 +1,172 @@
+# Email
+
+`email.q` provides a self-contained HTML email module. It supports two transports: the system `sendmail` utility, or SMTP via `curl`. HTML construction utilities are ported from [qmail](https://github.com/BestiaPL/qmail).
+
+Alert and report result handlers compatible with the TorQ reporter process are included, ported from `code/processes/reporter.q`.
+
+## Requirements
+
+One of the following must be installed and configured:
+
+- **sendmail** — `sudo apt install sendmail` or equivalent. Used when no `smtpurl` is configured.
+- **curl** — used when `smtpurl` is set in config. Most systems have this by default.
+
+## Configuration
+
+Passed as the first dictionary to `init`. All keys are optional.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `mailfrom` | string or symbol | `"torq@localhost"` | From address on outgoing emails |
+| `enabled` | boolean | `0b` | Set `1b` to allow emails to be sent |
+| `smtpurl` | string or symbol | `""` | SMTP server URL e.g. `"smtp://smtp.gmail.com:587"`. When set, curl is used instead of sendmail |
+| `smtpuser` | string or symbol | `""` | SMTP username |
+| `smtppassword` | string | `""` | SMTP password |
+| `smtpssl` | boolean | `1b` | Require TLS (`--ssl-reqd`). Set `0b` to disable |
+
+## Dependencies
+
+Passed as the second dictionary to `init`. Pass `(::)` to use all defaults.
+
+| Key | Required | Type | Description |
+|---|---|---|---|
+| `` `log `` | yes | dict | Logger with keys `` `info`warn`error ``, each `{[c;m]}`. Required — `init` throws if absent. See `di.log` for a default implementation. |
+| `` `send `` | no | function | `{[frm;to;sub;body;att]}` — injectable send function. Pass `(::)` or omit to use curl smtp when `smtpurl` is set, otherwise sendmail. |
+
+## Core Structures
+
+- **`history`** (table, `.z.M`) — Append-only log of every `senddefault` call:
+  - `time` (timestamp), `recipients` (symbol), `subject` (any), `status` (symbol: `` `sent `` / `` `failed `` / `` `disabled ``), `bytes` (long: `0j` on success, `-1j` on failure or disabled)
+- **`alertstats`** (keyed table, `.z.M`) — Tracks last alert send time per `procname`+`alertname` pair for cooldown enforcement
+
+## Main Functions
+
+### `init`
+Parameters: `[config; deps]`
+
+Initialises the module. Pass `(::)` for config to use defaults (email disabled, sendmail transport). A `log` dependency is always required — `init` throws if it is absent.
+
+When `smtpurl` is set in config and no custom `send` is injected, the curl SMTP transport is used automatically.
+
+### `senddefault`
+Parameters: `[msgdict]`
+
+Sends an HTML email. `msgdict` keys:
+- `to` — symbol or symbol list of recipients
+- `subject` — string
+- `body` — list of strings (plain strings are wrapped in a styled `<p>` tag; pre-built HTML strings are passed through as-is; a timestamp footer is appended automatically)
+- `attachment` — (optional) hsym file path
+
+Returns `1b` on success, `0b` on send failure, `-1` if disabled. Every attempt is logged to `history`.
+
+### `test`
+Parameters: `[to]`
+
+Sends a test email to `to` (symbol). Returns `1b` on success.
+
+### `alert`
+Parameters: `[period; recipients]`
+
+Returns a result handler projection `{[data]}` for the TorQ reporter `resulthandler` column.
+
+- `period` — timespan cooldown e.g. `00:02:00`
+- `recipients` — string or list of strings (email addresses)
+- `data.result` must have a `messages` column (list of strings)
+
+### `report`
+Parameters: `[temppath; recipients; filename; filetype]`
+
+Returns a result handler projection `{[data]}` for the TorQ reporter `resulthandler` column. Writes result to `temppath/filename.filetype`, emails it as an attachment, then deletes the temp file.
+
+### `getstatus`
+Returns the full `history` table.
+
+## HTML Helpers
+
+These functions are exported and can be used to build rich HTML email bodies before passing to `senddefault`.
+
+| Function | Parameters | Description |
+|---|---|---|
+| `addtext` | `[text]` | Wrap a string in a styled `<p>` tag |
+| `mailheading` | `[level; text]` | Heading `<h1>`–`<h4>` |
+| `mailbold` | `[text]` | Bold text |
+| `mailitalic` | `[text]` | Italic text |
+| `mailtable` | `[t]` | Render a q table as an HTML table |
+| `ztable` | `[t]` | Table with alternating row colours |
+| `maildict` | `[d]` | Render a q dict as an HTML table |
+| `zdict` | `[d]` | Dict table with alternating row colours |
+| `addcolor` | `[color; text]` | Apply font colour |
+| `mailbgcolor` | `[hex; text]` | Apply background colour |
+| `mailsize` | `[px; text]` | Set font size in pixels |
+| `mailcolors` | `[color; bg; size; text]` | Combined colour/background/size |
+| `mailurl` | `[url; text]` | Hyperlink |
+
+## Usage Examples
+
+### 1. Send a plain email via sendmail
+
+```q
+email:use`di.email
+email.init[`mailfrom`enabled!("me@example.com";1b);(::)]
+email.senddefault`to`subject`body!(`$"ops@example.com";"Deployed";enlist"Build 42 deployed.")
+```
+
+### 2. Send via SMTP
+
+```q
+email:use`di.email
+email.init[
+  `mailfrom`enabled`smtpurl`smtpuser`smtppassword!(
+    "me@example.com";
+    1b;
+    "smtp://smtp.gmail.com:587";
+    "me@example.com";
+    "mypassword");
+  (::)]
+email.senddefault`to`subject`body!(`$"ops@example.com";"Deployed";enlist"Build 42 deployed.")
+```
+
+### 3. Send an HTML table
+
+```q
+results:([]sym:`AAPL`GOOG;price:182.5 141.3)
+body:email.ztable[results]
+email.senddefault`to`subject`body!(`$"ops@example.com";"EOD Prices";body)
+```
+
+### 4. Test transport connectivity
+
+```q
+email.test[`$"me@example.com"]
+1b
+```
+
+### 5. Inject a logger
+
+```q
+log:use`di.log
+log.init[logconfig]
+logdep:`info`warn`error!(log.info;log.warn;log.error)
+email.init[emailconfig;`log`send!(logdep;::)]
+```
+
+### 6. Use as a reporter alert handler
+
+```
+rdbmemorycheck|.checks.memorycheck[1500000000]|email.alert[00:02;getenv`DEMOEMAILRECEIVER]|||rdb|rdb1|00:00:00|23:59:59|00:05:00|00:00:20|0 1 2 3 4 5 6
+```
+
+### 7. Use as a reporter report handler
+
+```
+eodreport|hloc[.proc.cd[];.proc.cd[];0D01]|email.report[getenv[`TORQHOME];getenv`DEMOEMAILRECEIVER;"eodreport";"csv"]|||rdb||18:00|18:00|00:00|00:05|2 3 4 5 6
+```
+
+### 8. Testing with a mock send function
+
+```q
+mocksend:{[frm;to;sub;body;att]}
+email.init[`enabled!(enlist 1b);`log`send!(::;mocksend)]
+email.senddefault`to`subject`body!(`$"a@b.com";"test";enlist"hello")
+1b
+```

--- a/di/email/email.md
+++ b/di/email/email.md
@@ -166,11 +166,22 @@ These functions are exported and can be used to build rich HTML email bodies bef
 
 ## Usage Examples
 
+Every example requires a logger. Define one before calling `init`:
+
+```q
+logdep:`info`warn`error!(
+  {[c;m] -1 "INFO  [",string[c],"] ",m;};
+  {[c;m] -1 "WARN  [",string[c],"] ",m;};
+  {[c;m] -2 "ERROR [",string[c],"] ",m;});
+```
+
 ### 1. Send a plain email via sendmail
 
 ```q
 email:use`di.email
-email.init[`mailfrom`enabled!("me@example.com";1b);(::)]
+email.init[
+  `mailfrom`enabled!("me@example.com";1b);
+  `log`send!(logdep;::)]
 email.senddefault`to`subject`body!(`$"ops@example.com";"Deployed";enlist"Build 42 deployed.")
 ```
 
@@ -184,14 +195,18 @@ email.init[
     1b;
     "smtp://smtp.gmail.com:587";
     "me@example.com";
-    "mypassword");
-  (::)]
+    "myapppassword");
+  `log`send!(logdep;::)]
 email.senddefault`to`subject`body!(`$"ops@example.com";"Deployed";enlist"Build 42 deployed.")
 ```
 
 ### 3. Send an HTML table
 
 ```q
+email:use`di.email
+email.init[
+  `mailfrom`enabled!("me@example.com";1b);
+  `log`send!(logdep;::)]
 results:([]sym:`AAPL`GOOG;price:182.5 141.3)
 body:email.ztable[results]
 email.senddefault`to`subject`body!(`$"ops@example.com";"EOD Prices";body)
@@ -200,36 +215,33 @@ email.senddefault`to`subject`body!(`$"ops@example.com";"EOD Prices";body)
 ### 4. Test transport connectivity
 
 ```q
+email:use`di.email
+email.init[
+  `mailfrom`enabled!("me@example.com";1b);
+  `log`send!(logdep;::)]
 email.test[`$"me@example.com"]
-1b
 ```
 
-### 5. Inject a logger
-
-```q
-log:use`di.log
-log.init[logconfig]
-logdep:`info`warn`error!(log.info;log.warn;log.error)
-email.init[emailconfig;`log`send!(logdep;::)]
-```
-
-### 6. Use as a reporter alert handler
+### 5. Use as a reporter alert handler
 
 ```
 rdbmemorycheck|.checks.memorycheck[1500000000]|email.alert[00:02;getenv`DEMOEMAILRECEIVER]|||rdb|rdb1|00:00:00|23:59:59|00:05:00|00:00:20|0 1 2 3 4 5 6
 ```
 
-### 7. Use as a reporter report handler
+### 6. Use as a reporter report handler
 
 ```
 eodreport|hloc[.proc.cd[];.proc.cd[];0D01]|email.report[getenv[`TORQHOME];getenv`DEMOEMAILRECEIVER;"eodreport";"csv"]|||rdb||18:00|18:00|00:00|00:05|2 3 4 5 6
 ```
 
-### 8. Testing with a mock send function
+### 7. Testing with a mock send function
 
 ```q
+mocklog:`info`warn`error!({[c;m]};{[c;m]};{[c;m]})
 mocksend:{[frm;to;sub;body;att]}
-email.init[`enabled!(enlist 1b);`log`send!(::;mocksend)]
+email:use`di.email
+email.init[
+  `mailfrom`enabled!("me@example.com";1b);
+  `log`send!(mocklog;mocksend)]
 email.senddefault`to`subject`body!(`$"a@b.com";"test";enlist"hello")
-1b
 ```

--- a/di/email/email.md
+++ b/di/email/email.md
@@ -8,8 +8,71 @@ Alert and report result handlers compatible with the TorQ reporter process are i
 
 One of the following must be installed and configured:
 
-- **sendmail** — `sudo apt install sendmail` or equivalent. Used when no `smtpurl` is configured.
+- **sendmail via msmtp** — lightweight sendmail replacement. Used when no `smtpurl` is configured. See [Sendmail setup (msmtp)](#sendmail-setup-msmtp) below.
 - **curl** — used when `smtpurl` is set in config. Most systems have this by default.
+
+## Sendmail setup (msmtp)
+
+`msmtp` is the recommended sendmail transport. It acts as a drop-in `sendmail` replacement and routes mail through an SMTP relay.
+
+### 1. Install
+
+```bash
+sudo apt install msmtp msmtp-mta
+```
+
+`msmtp-mta` creates the `/usr/sbin/sendmail` symlink that the module uses.
+
+### 2. Configure
+
+Create `~/.msmtprc`:
+
+```
+defaults
+auth           on
+tls            on
+tls_trust_file /etc/ssl/certs/ca-certificates.crt
+logfile        ~/.msmtp.log
+
+account        default
+host           smtp.gmail.com
+port           587
+from           me@example.com
+user           me@example.com
+password       myapppassword
+```
+
+Set permissions (msmtp refuses to run if the file is world-readable):
+
+```bash
+chmod 600 ~/.msmtprc
+```
+
+For Gmail, `password` must be an [App Password](https://myaccount.google.com/apppasswords) — not your account password. App Passwords require 2-Step Verification to be enabled on the account.
+
+### 3. Test outside q
+
+```bash
+echo -e "To: me@example.com\nSubject: test\n\ntest body" | sendmail me@example.com
+cat ~/.msmtp.log
+```
+
+A successful send logs `exitcode=EX_OK`. If it fails, the log contains the SMTP error.
+
+### 4. Test from q
+
+```q
+email:use`di.email
+log:use`di.log
+log.init[logconfig]
+logdep:`info`warn`error!(log.info;log.warn;log.error)
+
+email.init[
+  `mailfrom`enabled!("me@example.com";1b);
+  `log`send!(logdep;::)]
+
+email.test[`$"me@example.com"]
+```
 
 ## Configuration
 

--- a/di/email/email.q
+++ b/di/email/email.q
@@ -1,0 +1,428 @@
+/ module for sending html emails via the system sendmail utility
+/ ported from torq code/common/email.q and code/processes/reporter.q
+/ html construction and sendmail transport ported from qmail (github.com/BestiaPL/qmail)
+/ no c library or smtp server required
+
+/ ============================================================
+/ sendmail utilities (ported from qmail)
+/ ============================================================
+
+utilityexists:{not 0b~@[system;"which ",x," 2>/dev/null";{0b}]};
+
+hsym2str:{[x] $[":"=first s:string x;1_s;s]};
+
+checkfile:{if[not x~key x:hsym x;'"file not found: ",hsym2str x]};
+
+base64encode:$[.z.K >= 3.6;76 cut .Q.btoa@;{
+  c:count[x]mod 3;
+  pc:count p:(0x;0x0000;0x00)c;
+  b:.Q.b6 2 sv/: 6 cut raze 0b vs/: x,p;
+  76 cut(neg[pc] _ b),pc#"="}];
+
+encodefile:{
+  checkfile x;
+  base64encode read1 x;
+  };
+
+mimetype:{[a]
+  if[not utilityexists "file"; :"text/plain"];
+  checkfile a;
+  trim last ":" vs first @[system;"file --mime-type ",hsym2str a;{enlist ": text/plain"}];
+  };
+
+mailheader:{[]
+  ("<html>";"<body style=\"width:100%; margin:0; padding:0; font-size:15px;\">")
+  };
+
+mailfooter:("</body>";"</html>");
+
+template0:{[frm;to;sub;body]
+  enlist["From: ",frm],
+  enlist["To: ",to],
+  enlist["Subject: ",sub],
+  enlist["MIME-Version: 1.0"],
+  enlist["Content-Type: text/html; charset=UTF-8"],
+  enlist[""],
+  mailheader[],
+  body,
+  mailfooter
+  };
+
+mailtemplate:{[frm;to;sub;body;att]
+  if[not count att where not null att,:();:template0[frm;to;sub;body]];
+  boundary:"====",string[rand 0Ng],"====";
+  enlist["From: ",frm],
+  enlist["To: ",to],
+  enlist["Subject: ",sub],
+  enlist["Content-Type: multipart/mixed; boundary=\"",boundary,"\""],
+  enlist["MIME-Version: 1.0"],
+  enlist[""],
+  enlist["--",boundary],
+  enlist["Content-Type: text/html"],
+  enlist[""],
+  mailheader[],
+  body,
+  mailfooter,
+  (raze {[a;boundary]
+    fn:last "/"vs hsym2str a;
+    enlist[""],
+    enlist["--",boundary],
+    enlist["Content-Transfer-Encoding: base64"],
+    enlist["Content-Type: ",mimetype[a],"; name=",fn],
+    enlist["Content-Disposition: attachment; filename=",fn],
+    enlist[""],
+    encodefile[a]
+  }[;boundary] each att),
+  enlist["--",boundary,"--"]
+  };
+
+mailsend:{[frm;to;sub;body;att]
+  / send an html email via the system sendmail utility
+  / frm  - string from address
+  / to   - string, comma-delimited recipient addresses
+  / sub  - string subject
+  / body - list of strings (html content)
+  / att  - "" for no attachment, or list of hsym file paths
+  if[not utilityexists "sendmail";'"sendmail not found on this system"];
+  if[not att~"";if[10h=type att;att:enlist att]];
+  fn:hsym`$first system"mktemp /tmp/qmail.XXXXXXXXXX";
+  fn 0: mailtemplate[frm;to;sub;body;att];
+  @[system;"sendmail -t < ",1_string fn;{[fn;e]hdel fn;'"sendmail error: ",e}[fn]];
+  hdel fn;
+  };
+
+/ ============================================================
+/ html construction helpers (ported from qmail)
+/ ============================================================
+
+mailstring:{$[10h=abs type x;x;(type[x] in 0 98 99h) or (100h<type x) or 0h<type x;.Q.s1 x;string x]};
+
+dict2css:{";"sv":"sv'flip(string@key@;value)@\:x};
+
+cssbody:{(!) . flip 2 cut(
+  `$"font-family";"Verdana, Geneva, Sans-Serif";
+  `$"color";"#2f4a5c")};
+
+csstableall:{cssbody[],(!) . flip 2 cut(
+  `$"font-family";"Verdana, Geneva, Sans-Serif";
+  `$"font-size";"15px";
+  `margin;"0 ";
+  `padding;"3px";
+  `$"line-height";"100%";
+  `$"text-align";"left";
+  `color;"#069";
+  `$"border-width";"2px";
+  `$"border-collapse";"collapse";
+  `$"background-color";"#ffffff";
+  `$"border-color";"#ffffff")};
+
+csstableheader:{csstableall[],(!) . flip 2 cut(
+  `$"border-style";"solid";
+  `$"background-color";"#5473bf";
+  `color;"#ffffff";
+  `$"border-color";"#ffffff";
+  `$"border-width";"2px")};
+
+csstablerowall:{csstableall[],(!) . flip 2 cut(
+  `$"border-style";"solid";
+  `$"border-width";"2px";
+  `$"border-color";"#ffffff")};
+
+csstablerowodd:{csstablerowall[],enlist[`$"background-color"]!enlist "#e6e6ff"};
+
+csstableroweven:{csstablerowall[],enlist[`$"background-color"]!enlist "#ffffff"};
+
+getstyle:{[x]
+  k:(),x;
+  $[k~enlist `body; cssbody[];
+    k~`table`all; csstableall[];
+    k~`table`header; csstableheader[];
+    k~`table`row`all; csstablerowall[];
+    k~`table`row`odd; csstablerowodd[];
+    csstableroweven[]]
+  };
+
+addstyle:{x," style=\"",(dict2css getstyle[y]),"\""};
+
+mailwrap:{"<",x,">",y,"</",(first " "vs (),x),">"};
+mailewrap:{enlist["<",x,">"],y,enlist"</",(first " "vs (),x),">"};
+
+addtext:{mailwrap[addstyle["p";`body];x]};
+mailheading:{mailwrap[addstyle["h",x;`body];y]};
+mailbold:{mailwrap[addstyle["b";`body];mailstring x]};
+mailitalic:{mailwrap[addstyle["i";`body];mailstring x]};
+
+mailcolors:{[color;bg;sz;text]
+  styledict:(`$("color";"background-color";"font-size";"display"))!(color;bg;$[count sz;sz,"px";""];"inline");
+  styledict:#[;styledict]where not ""~/:styledict;
+  mailwrap["p style=\"",(dict2css cssbody[],styledict),"\"";mailstring[text]]};
+
+addcolor:{mailcolors[x;"";"";y]};
+mailsize:{mailcolors["";"";x;y]};
+mailbgcolor:{mailcolors["";x;"";y]};
+
+mailurl:{[u;txt]mailwrap[addstyle["a href=\"",u,"\"";`body];txt]};
+setbookmark:{[id]"<a name=\"",id,"\"></a>"};
+getbookmark:{[id;txt]mailurl["#",id;txt]};
+
+mailrow:{mailewrap["tr";mailwrap[x]each mailstring each y]};
+
+table0:{[t;alt]
+  h:mailrow[addstyle["th";`table`header];cols t];
+  b:raze mailrow'[addstyle["td"] each`table`row,/:$[alt;?[1=til[count t]mod 2;`odd;`even];count[t]#`even];flip value flip 0!t];
+  mailewrap[addstyle["table";`table`all];h,b]
+  };
+
+mailtable:{table0[x;0b]};
+ztable:{table0[x;1b]};
+
+dict0:{[d;alt]
+  b:raze mailrow'[addstyle["td"] each`table`row,/:$[alt;?[1=til[count d]mod 2;`odd;`even];count[d]#`even];flip(key;value)@\:d];
+  mailewrap["table";b]
+  };
+
+maildict:{dict0[x;0b]};
+zdict:{dict0[x;1b]};
+
+colornormalize:{[low;high;x]0f | 1f & (x - low)%(high - low)};
+colorhex2html:{"#",raze string x};
+
+colorhsv2rgb:{[h;s;v]
+  C:v*s;
+  H:(h mod 360f)%60f;
+  X:C * 1 - abs -1f + H mod 2;
+  m:v-C;
+  D:`s#0 1 2 3 4 5 6f!(1 2 0;2 1 0;0 1 2;0 2 1;2 0 1;1 0 2;0 0 0);
+  `byte$255*m + (0f;C;X)D H
+  };
+
+colorhuemap:(!). flip (
+  (`red;0);(`orange;30);(`yellow;60);(`lime;90);(`green;120);
+  (`turquoise;150);(`cyan;180);(`blue;240);(`purple;270);
+  (`pink;300);(`violet;330));
+
+colorizemono:{[color;min_val;max_val;x]
+  s_values:colornormalize[min_val;max_val;x];
+  colorhsv2rgb[$[-11h=type color;colorhuemap[color];color];;1f]each s_values
+  };
+
+colorizestereo:{[color_min;color_max;min_val;max_val;pivot_val;x]
+  low:x<pivot_val;
+  low_colors:colorizemono[color_min;pivot_val;min_val;x where low];
+  high_colors:colorizemono[color_max;pivot_val;max_val;x where not low];
+  @[;where not low;:;high_colors] @[;where low;:;low_colors] count[x]#enlist 0x000000
+  };
+
+/ ============================================================
+/ module state and defaults
+/ ============================================================
+
+/ from address used in all outgoing emails - overwritten by init
+mailfrom:"torq@localhost";
+
+/ email gate - overwritten by init
+enabled:0b;
+
+/ append-only table recording every send attempt
+history:([]time:`timestamp$();recipients:`symbol$();subject:();status:`symbol$();bytes:`long$());
+
+/ keyed table tracking last alert send time per procname+alertname pair (for cooldown)
+alertstats:([procname:`symbol$();alertname:`symbol$()] lastsent:`timestamp$());
+
+/ default send wraps mailsend - can be overridden in deps for testing
+defaultsend:{[frm;to;sub;body;att]mailsend[frm;to;sub;body;att]};
+send:defaultsend;
+
+/ smtp config - set by init when smtpurl is provided; used by smtpsend_
+smtpurl:"";
+smtpuser:"";
+smtppassword:"";
+smtpssl:1b;
+
+/ ============================================================
+/ internal helpers
+/ ============================================================
+
+smtpsend_:{[frm;to;sub;body;att]
+  / send via curl smtp transport using module smtp config (smtpurl/smtpuser/smtppassword/smtpssl)
+  / signature matches mailsend: frm to sub body att
+  if[not utilityexists "curl";'"curl not found on this system"];
+  if[not att~"";if[10h=type att;att:enlist att]];
+  / keep tmpfile as a plain string to avoid type issues when building cmd
+  tmpfile:first system"mktemp /tmp/qmail.XXXXXXXXXX";
+  fn:hsym`$tmpfile;
+  .[{[a;b]a 0: b};(fn;mailtemplate[frm;to;sub;body;att]);{[fn;e]hdel fn;'"smtp write error: ",e}[fn]];
+  rcpts:" " sv {[r]"--mail-rcpt '",r,"'"}each ","vs to;
+  sslopt:$[smtpssl;"--ssl-reqd ";""];
+  cmd:"curl --url '",smtpurl,"' ",sslopt,"--crlf --mail-from '",frm,"' ",rcpts," --user '",smtpuser,":",smtppassword,"' --upload-file ",tmpfile," 2>&1";
+  @[{system x};cmd;{[fn;e]hdel fn;'"curl smtp error: ",e}[fn]];
+  hdel fn;
+  };
+
+stringnestedlists:{[res]
+  / convert any nested int/float list columns to space-delimited strings for serialisation
+  / ported from torq reporter.q stringnestedlists
+  nestedtypes:upper .Q.t except " c";
+  $[count select from meta[res] where t in nestedtypes;
+    {[t;c] ![t;();0b;(enlist c)!enlist((';{" " sv string x});c)]}/[res;exec c from meta[res] where t in nestedtypes];
+    res];
+  };
+
+writetofile:{[temppath;reportname;filetype;data]
+  / write data`result to disk as csv or txt and return the file path hsym
+  / ported from torq reporter.q writetofile
+  ty:`$filetype;
+  if[not ty in key .h.tx;
+    .z.m.logerr[`email;"writetofile: filetype not supported: ",filetype];
+    'filetype," is not a supported file type";
+  ];
+  res:stringnestedlists[data`result];
+  filepath:`$temppath,"/",reportname,".",filetype;
+  .[{hsym[x] 0:.h.tx[y;z]};(filepath;ty;res);{[e].z.m.logerr[`email;"writetofile: ",e]}];
+  :hsym filepath;
+  };
+
+loghistory:{[recipients;subject;status;bytes]
+  / append one row to the persistent send history table
+  .z.M.history insert (.z.p;recipients;subject;status;`long$bytes);
+  };
+
+/ ============================================================
+/ public api
+/ ============================================================
+
+senddefault:{[msgdict]
+  / send an html email via the system sendmail utility
+  / msgdict keys: to (symbol or symbol list), subject (string), body (list of strings)
+  /               optionally: attachment (file path hsym)
+  / returns 1b on success, 0b on send failure, -1 if disabled
+  if[not enabled;
+    .z.m.logerr[`email;"email sending is not enabled"];
+    loghistory[msgdict`to;msgdict`subject;`disabled;-1];
+    :-1;
+  ];
+  to:","sv string$[-11h=type msgdict`to;enlist msgdict`to;msgdict`to];
+  htmlbody:{$[10h=type x;$[count x;$["<"=first x;x;addtext x];""];x]}'[msgdict[`body],enlist "email generated at ",(string .z.p)];
+  att:$[`attachment in key msgdict;enlist msgdict`attachment;""];
+  res:.[send;(mailfrom;to;msgdict`subject;htmlbody;att);{[e].z.m.logerr[`email;"send failed: ",e];0b}];
+  ok:not res~0b;
+  loghistory[msgdict`to;msgdict`subject;`failed`sent ok;$[ok;0j;-1j]];
+  $[ok;
+    .z.m.loginfo[`email;"email sent"];
+    .z.m.logerr[`email;"failed to send email"]];
+  :ok;
+  };
+
+test:{[to]
+  / send a test email to verify sendmail connectivity
+  / to - symbol e.g. `$"user@example.com"
+  / returns 1b on success, 0b on failure
+  :senddefault`to`subject`body!(to;"test email";enlist"this is a test email to verify sendmail is configured correctly");
+  };
+
+alerthandler:{[period;recipients;data]
+  / result handler for the torq reporter alert - invoked via the alert[] projection
+  / ported from torq reporter.q emailalert
+  / period     - timespan cooldown e.g. 00:02:00
+  / recipients - string or list of strings (email addresses)
+  / data       - reporter data dict: result (table with messages col), name, procname, queryid
+  lasttime:0p^exec first lastsent from alertstats where procname=(data`procname),alertname=(data`name);
+  result:data`result;
+  if[not count result;
+    .z.m.loginfo[`email;"emailalert: nothing to email"];
+    :();
+  ];
+  if[period > .z.p - lasttime;
+    .z.m.loginfo[`email;"emailalert: suppressed, previous email was too recent"];
+    :();
+  ];
+  .z.M.alertstats upsert (data`procname;data`name;.z.p);
+  subject:"Process [",(string data`procname),"] has triggered an alert [",(string data`name),"]";
+  .z.m.loginfo[`email;"emailalert: sending warning email"];
+  res:senddefault[`to`subject`body!(`$recipients;subject;(),result`messages)];
+  $[res>0;
+    .z.m.loginfo[`email;"emailalert: sent alert for: ",string data`name];
+    .z.m.logerr[`email;"emailalert: failed to send alert for: ",string data`name]];
+  };
+
+alert:{[period;recipients]
+  / create a reporter result handler that sends an alert email with cooldown
+  / period     - timespan cooldown between successive alerts e.g. 00:02:00
+  / recipients - string or list of strings (email addresses)
+  / returns a projection {[data]} compatible with the torq reporter resulthandler column
+  :alerthandler[period;recipients;];
+  };
+
+reporthandler:{[temppath;recipients;filename;filetype;data]
+  / result handler for the torq reporter report - invoked via the report[] projection
+  / ported from torq reporter.q emailreport
+  / temppath   - string path for temporary report files e.g. getenv[`TORQHOME]
+  / recipients - string or list of strings (email addresses)
+  / filename   - string output filename stem and email subject label
+  / filetype   - string file format e.g. "csv" or "txt"
+  / data       - reporter data dict: result (table), name, queryid
+  filepath:writetofile[temppath;filename;filetype;data];
+  subject:"Report '",(string data`name),"' has been generated [",(string .z.d),"]";
+  body:"A report has been generated. Please see the attached file for the results.";
+  .z.m.loginfo[`email;"emailreport: sending email with attached report"];
+  res:senddefault[`to`subject`body`attachment!(`$recipients;subject;enlist body;filepath)];
+  if[res<1;.z.m.logerr[`email;"emailreport: failed to send email"]];
+  .z.m.loginfo[`email;"emailreport: removing temporary file: ",string filepath];
+  @[hdel;filepath;{[e].z.m.logerr[`email;"emailreport: failed to delete temp file: ",e]}];
+  };
+
+report:{[temppath;recipients;filename;filetype]
+  / create a reporter result handler that writes the result to file and emails it as an attachment
+  / temppath   - string path for temporary report files e.g. getenv[`TORQHOME]
+  / recipients - string or list of strings (email addresses)
+  / filename   - string output filename stem and email subject label
+  / filetype   - string file format e.g. "csv" or "txt"
+  / returns a projection {[data]} compatible with the torq reporter resulthandler column
+  :reporthandler[temppath;recipients;filename;filetype;];
+  };
+
+getstatus:{[]
+  / return the full send history table
+  :history;
+  };
+
+init:{[config;deps]
+  / initialise module with email config and optional injected dependencies
+  / config - dict with any of:
+  /   mailfrom (string or symbol) - from address
+  /   enabled  (boolean)          - gate for sending
+  /   smtpurl  (string or symbol) - e.g. "smtp://smtp.gmail.com:587"
+  /   smtpuser (string or symbol) - smtp username
+  /   smtppassword (string)       - smtp password
+  /   smtpssl  (boolean)          - require tls (default 1b)
+  / pass (::) for config to use defaults (email disabled, sendmail transport)
+  / deps - `log`send!(logdict;sendfunc)
+  /   `log:  `info`warn`error!({[c;m]};{[c;m]};{[c;m]}) - required; init throws if absent
+  /   `send: {[frm;to;sub;body;att]}                    - optional, (::) = use smtp or sendmail
+  / examples:
+  /   email.init[config; `log`send!(logdep; ::)]     / inject log, default send
+  /   email.init[config; `log`send!(logdep; mysend)] / inject both
+  .z.m.mailfrom:"torq@localhost";
+  .z.m.enabled:0b;
+  .z.m.smtpurl:"";
+  .z.m.smtpuser:"";
+  .z.m.smtppassword:"";
+  .z.m.smtpssl:1b;
+  logdict:$[99h=type deps;$[(`log in key deps) and not (::)~deps`log;deps`log;()!()];()!()];
+  if[not count logdict;'"di.email: log dependency is required; pass `log`send!(logdep;::) - see di.log"];
+  .z.m.loginfo:logdict`info;
+  .z.m.logwarn:logdict`warn;
+  .z.m.logerr:logdict`error;
+  sendinjected:$[99h=type deps;(`send in key deps) and not (::)~deps`send;0b];
+  .z.m.send:$[sendinjected;deps`send;defaultsend];
+  if[99h=type config;
+    if[`mailfrom in key config;.z.m.mailfrom:$[10h=type config`mailfrom;config`mailfrom;string config`mailfrom]];
+    if[`enabled in key config;.z.m.enabled:config`enabled];
+    if[`smtpurl in key config;.z.m.smtpurl:$[10h=type config`smtpurl;config`smtpurl;string config`smtpurl]];
+    if[`smtpuser in key config;.z.m.smtpuser:$[10h=type config`smtpuser;config`smtpuser;string config`smtpuser]];
+    if[`smtppassword in key config;.z.m.smtppassword:$[10h=type config`smtppassword;config`smtppassword;string config`smtppassword]];
+    if[`smtpssl in key config;.z.m.smtpssl:config`smtpssl];
+  ];
+  / if smtp url is configured and send was not explicitly injected, use curl smtp transport
+  if[count smtpurl;if[not sendinjected;.z.m.send:smtpsend_]];
+  };

--- a/di/email/init.q
+++ b/di/email/init.q
@@ -1,0 +1,4 @@
+/ load core functionality and bundled sendmail/html utilities
+\l ::email.q
+
+export:([init;senddefault;test;alert;report;getstatus])

--- a/di/email/test.csv
+++ b/di/email/test.csv
@@ -1,0 +1,200 @@
+action,ms,bytes,lang,code,repeat,minver,comment
+before,0,0,q,email:use`di.email,1,1,load module into session
+before,0,0,q,mocklog:`info`warn`error!({[c;m]};{[c;m]};{[c;m]}),1,1,define no-op mock logger
+before,0,0,q,"mocksend:{[frm;to;sub;body;att]}",1,1,define no-op mock send (no sendmail call)
+
+/ Test 0: init with defaults leaves email disabled and config empty
+run,0,0,q,"email.init[(::);`log`send!(mocklog;::)]",1,1,init with defaults and injected logger
+true,0,0,q,not .m.di.0email.enabled,1,1,email disabled by default
+true,0,0,q,"""torq@localhost""~.m.di.0email.mailfrom",1,1,default mailfrom is torq@localhost
+
+/ Test 1: init with custom config sets values correctly
+run,0,0,q,"email.init[`mailfrom`enabled!(""me@example.com"";0b);`log`send!(mocklog;::)]",1,1,init with string mailfrom
+true,0,0,q,"""me@example.com""~.m.di.0email.mailfrom",1,1,mailfrom set from string
+run,0,0,q,"email.init[`mailfrom`enabled!(`$""me@example.com"";0b);`log`send!(mocklog;::)]",1,1,init with symbol mailfrom
+true,0,0,q,"""me@example.com""~.m.di.0email.mailfrom",1,1,symbol mailfrom converted to string
+
+/ Test 2: init wires injected logger into individual loginfo/logwarn/logerr slots
+run,0,0,q,"email.init[(::);`log`send!(mocklog;::)]",1,1,init with injected logger
+true,0,0,q,mocklog[`info]~.m.di.0email.loginfo,1,1,injected info function stored
+true,0,0,q,mocklog[`warn]~.m.di.0email.logwarn,1,1,injected warn function stored
+true,0,0,q,mocklog[`error]~.m.di.0email.logerr,1,1,injected error function stored
+
+/ Test 3: init errors when log dep not provided
+fail,0,0,q,email.init[(::);(::)],1,1,init without log dep throws an error
+fail,0,0,q,"email.init[(::);`log`send!(::;mocksend)]",1,1,init with log set to (::) throws an error
+
+/ Test 4: init wires injected send function
+run,0,0,q,"email.init[(::);`log`send!(mocklog;mocksend)]",1,1,init with injected send
+true,0,0,q,mocksend~.m.di.0email.send,1,1,injected send stored
+
+/ Test 5: init falls back to defaultsend when send dep not provided
+run,0,0,q,"email.init[(::);`log`send!(mocklog;::)]",1,1,init with log injected but no send dep
+true,0,0,q,.m.di.0email.defaultsend~.m.di.0email.send,1,1,default send used
+
+/ Test 6: senddefault returns -1 and logs disabled entry when email is disabled
+run,0,0,q,"email.init[(::);`log`send!(mocklog;::)]",1,1,reset to defaults (disabled)
+run,0,0,q,before:count email.getstatus[],1,1,capture history row count
+run,0,0,q,"res:email.senddefault[`to`subject`body!(`$""a@b.com"";""subj"";enlist""body"")]",1,1,send while disabled
+true,0,0,q,-1~res,1,1,returns -1 when disabled
+true,0,0,q,1=(count email.getstatus[])-before,1,1,one row appended to history
+true,0,0,q,`disabled~last exec status from email.getstatus[],1,1,status is disabled
+
+/ Test 7: senddefault with injected send returns 1b on success
+run,0,0,q,"email.init[`mailfrom`enabled!(""me@example.com"";1b);`log`send!(mocklog;mocksend)]",1,1,init with mock send and enabled
+run,0,0,q,before:count email.getstatus[],1,1,capture history row count
+run,0,0,q,"res:email.senddefault[`to`subject`body!(`$""a@b.com"";""subj"";enlist""body"")]",1,1,send with mock send
+true,0,0,q,1b~res,1,1,returns 1b on success
+true,0,0,q,1=(count email.getstatus[])-before,1,1,one row appended to history
+true,0,0,q,`sent~last exec status from email.getstatus[],1,1,status is sent
+
+/ Test 8: senddefault with failing send returns 0b and logs failed status
+run,0,0,q,"failsend:{[frm;to;sub;body;att]'""smtp error""}",1,1,define failing send
+run,0,0,q,"email.init[(enlist`enabled)!enlist 1b;`log`send!(mocklog;failsend)]",1,1,init with failing send
+run,0,0,q,before:count email.getstatus[],1,1,capture count
+run,0,0,q,"res:email.senddefault[`to`subject`body!(`$""a@b.com"";""subj"";enlist""body"")]",1,1,invoke send that throws
+true,0,0,q,0b~res,1,1,returns 0b on failure
+true,0,0,q,`failed~last exec status from email.getstatus[],1,1,status is failed
+
+/ Test 9: getstatus returns history table with expected columns and correct type
+run,0,0,q,h:email.getstatus[],1,1,fetch history
+true,0,0,q,`time`recipients`subject`status`bytes~cols h,1,1,correct column names
+true,0,0,q,98h=type h,1,1,history is a table
+
+/ Test 10: alert handler returns empty on empty result
+run,0,0,q,"email.init[(::);`log`send!(mocklog;::)]",1,1,reset
+run,0,0,q,"h:email.alert[0D00:02;""a@b.com""]",1,1,create alert handler
+run,0,0,q,"data:`procname`name`result`queryid!(`testproc;`testreport;([]messages:());1)",1,1,reporter data with empty result
+run,0,0,q,res:h[data],1,1,invoke handler
+true,0,0,q,()~res,1,1,empty result returns ()
+
+/ Test 11: alert handler attempts send on non-empty result
+run,0,0,q,"email.init[(enlist`enabled)!enlist 1b;`log`send!(mocklog;mocksend)]",1,1,init with mock send
+run,0,0,q,before:count email.getstatus[],1,1,capture count
+run,0,0,q,"h:email.alert[0D00:02;""a@b.com""]",1,1,fresh handler
+run,0,0,q,"data:`procname`name`result`queryid!(`testproc;`newreport;([]messages:enlist""mem high"");1)",1,1,non-empty result
+run,0,0,q,h[data],1,1,invoke handler
+true,0,0,q,1=(count email.getstatus[])-before,1,1,one send attempt logged
+
+/ Test 12: alert handler respects cooldown for same procname+alertname
+run,0,0,q,before:count email.getstatus[],1,1,capture count
+run,0,0,q,h[data],1,1,second call within cooldown window
+true,0,0,q,before=count email.getstatus[],1,1,no send within cooldown window
+
+/ Test 13: alert handler allows send for different alertname
+run,0,0,q,before:count email.getstatus[],1,1,capture count
+run,0,0,q,"data2:`procname`name`result`queryid!(`testproc;`otheralert;([]messages:enlist""row low"");2)",1,1,different alert name
+run,0,0,q,h[data2],1,1,invoke handler with different name
+true,0,0,q,1=(count email.getstatus[])-before,1,1,separate cooldown per alertname
+
+/ Test 14: report handler writes file and logs send attempt
+run,0,0,q,temppath:system"cd",1,1,use cwd as temppath
+run,0,0,q,rh:email.report[temppath;"a@b.com";"testreport";"csv"],1,1,create report handler
+run,0,0,q,"rdata:`procname`name`result`queryid!(`testproc;`testreport;([]sym:`a`b;price:1.0 2.0);1)",1,1,reporter data dict
+run,0,0,q,before:count email.getstatus[],1,1,capture count
+run,0,0,q,rh[rdata],1,1,invoke handler
+true,0,0,q,1=(count email.getstatus[])-before,1,1,one send attempt logged
+true,0,0,q,"not (hsym`$temppath,""/testreport.csv"") in key hsym`$temppath",1,1,temp file cleaned up
+
+/ Test 15: addtext wraps text in styled <p>
+run,0,0,q,"t:.m.di.0email.addtext ""hello""",1,1,build addtext result
+true,0,0,q,"""<p ""~3#t",1,1,addtext starts with <p tag
+true,0,0,q,"""</p>""~-4#t",1,1,addtext closes with </p>
+true,0,0,q,"0<count t ss ""hello""",1,1,addtext preserves text content
+
+/ Test 16: mailheading produces heading tags
+run,0,0,q,"h1:.m.di.0email.mailheading[""1"";""title""]",1,1,build h1 heading
+true,0,0,q,"""<h1 ""~4#h1",1,1,mailheading h1 opens with tag
+true,0,0,q,"""</h1>""~-5#h1",1,1,mailheading h1 closes
+true,0,0,q,"0<count h1 ss ""title""",1,1,mailheading contains heading text
+
+/ Test 17: mailbold and mailitalic produce inline tags
+run,0,0,q,"mbi:.m.di.0email.mailbold ""x""",1,1,build bold span
+true,0,0,q,"""<b ""~3#mbi",1,1,mailbold opens with <b tag
+true,0,0,q,"""</b>""~-4#mbi",1,1,mailbold closes with </b>
+run,0,0,q,"mii:.m.di.0email.mailitalic ""x""",1,1,build italic span
+true,0,0,q,"""<i ""~3#mii",1,1,mailitalic opens with <i tag
+true,0,0,q,"""</i>""~-4#mii",1,1,mailitalic closes with </i>
+
+/ Test 18: mailstring converts types to strings
+true,0,0,q,"""hello""~.m.di.0email.mailstring ""hello""",1,1,mailstring passes through string
+true,0,0,q,"""abc""~.m.di.0email.mailstring `abc",1,1,mailstring converts symbol to string
+
+/ Test 19: addcolor sets only color - no spurious font-size (mailcolors bug fix)
+run,0,0,q,"ac:.m.di.0email.addcolor[""red"";""text""]",1,1,build addcolor result
+true,0,0,q,"0<count ac ss ""color:red""",1,1,addcolor sets color property
+true,0,0,q,"0=count ac ss ""font-size:px""",1,1,addcolor does not produce invalid font-size:px
+
+/ Test 20: mailsize sets font-size with px suffix
+run,0,0,q,"ms:.m.di.0email.mailsize[""20"";""text""]",1,1,build mailsize result
+true,0,0,q,"0<count ms ss ""font-size:20px""",1,1,mailsize appends px to size value
+
+/ Test 21: mailbgcolor sets background-color
+run,0,0,q,"mbg:.m.di.0email.mailbgcolor[""#ffff00"";""text""]",1,1,build mailbgcolor result
+true,0,0,q,"0<count mbg ss ""background-color:#ffff00""",1,1,mailbgcolor sets background-color property
+
+/ Test 22: mailcolors sets all specified properties
+run,0,0,q,"mc:.m.di.0email.mailcolors[""blue"";""#ee"";""14"";""text""]",1,1,build mailcolors result
+true,0,0,q,"0<count mc ss ""color:blue""",1,1,mailcolors sets color
+true,0,0,q,"0<count mc ss ""font-size:14px""",1,1,mailcolors sets font-size
+true,0,0,q,"0<count mc ss ""display:inline""",1,1,mailcolors sets display
+
+/ Test 23: mailurl produces anchor tag with href
+run,0,0,q,"u:.m.di.0email.mailurl[""https://x.com"";""click""]",1,1,build mailurl
+true,0,0,q,"""<a ""~3#u",1,1,mailurl starts with <a tag
+true,0,0,q,"""</a>""~-4#u",1,1,mailurl closes with </a>
+true,0,0,q,"0<count u ss ""x.com""",1,1,mailurl embeds href url
+
+/ Test 24: setbookmark and getbookmark produce anchor elements
+run,0,0,q,"bm:.m.di.0email.setbookmark ""s1""",1,1,build anchor bookmark
+true,0,0,q,"0<count bm ss ""name=""",1,1,setbookmark has name attribute
+true,0,0,q,"0<count bm ss ""s1""",1,1,setbookmark embeds anchor id
+run,0,0,q,"gbm:.m.di.0email.getbookmark[""s1"";""go""]",1,1,build bookmark link
+true,0,0,q,"0<count gbm ss ""#s1""",1,1,getbookmark links to named anchor
+
+/ Test 25: mailtable produces html table with headers and data
+run,0,0,q,mt:.m.di.0email.mailtable[([]a:1 2;b:3 4)],1,1,build mailtable from kdb table
+true,0,0,q,0h=type mt,1,1,mailtable returns list of strings
+true,0,0,q,"""</table>""~last mt",1,1,mailtable closes with </table>
+true,0,0,q,"0<count(raze mt)ss ""<th """,1,1,mailtable has header cells
+true,0,0,q,"0<count(raze mt)ss ""<td """,1,1,mailtable has data cells
+true,0,0,q,"0=count(raze mt)ss ""#e6e6ff""",1,1,mailtable rows all same color no alternating
+
+/ Test 26: ztable produces alternating row colors
+run,0,0,q,zt:.m.di.0email.ztable[([]a:1 2 3 4;b:5 6 7 8)],1,1,build ztable
+true,0,0,q,"0<count(raze zt)ss ""#e6e6ff""",1,1,ztable has alternating odd row background
+
+/ Test 27: maildict renders key-value pairs as table rows
+run,0,0,q,"md:.m.di.0email.maildict[`k1`k2!(""v1"";""v2"")]",1,1,build maildict
+true,0,0,q,0h=type md,1,1,maildict returns list of strings
+true,0,0,q,"0<count(raze md)ss ""k1""",1,1,maildict renders key
+true,0,0,q,"0<count(raze md)ss ""v1""",1,1,maildict renders value
+
+/ Test 28: template0 has blank separator between headers and html body
+run,0,0,q,"tmpl:.m.di.0email.template0[""f"";""t"";""s"";enlist ""body""]",1,1,build template0
+true,0,0,q,"any """"~/:tmpl",1,1,template0 has blank separator line
+true,0,0,q,"any ""<html>""~/:tmpl",1,1,template0 has html open tag
+true,0,0,q,"(first where """"~/:tmpl)<first where ""<html>""~/:tmpl",1,1,blank separator comes before html body
+
+/ Test 29: dict2css produces semicolon-separated key:value css
+run,0,0,q,"css:.m.di.0email.dict2css[(`$""color"";`$""background-color"")!(""red"";""blue"")]",1,1,build css from two-key dict
+true,0,0,q,"0<count css ss ""color:red""",1,1,dict2css produces colon-separated key:val
+true,0,0,q,""";"" in css",1,1,dict2css separates properties with semicolon
+
+/ Test 30: getstyle returns correct css dict for each style key
+true,0,0,q,.m.di.0email.cssbody[]~.m.di.0email.getstyle[`body],1,1,getstyle body returns cssbody dict
+true,0,0,q,.m.di.0email.csstableall[]~.m.di.0email.getstyle[`table`all],1,1,getstyle table all
+true,0,0,q,.m.di.0email.csstableheader[]~.m.di.0email.getstyle[`table`header],1,1,getstyle table header
+
+/ Test 31: colornormalize scales and clamps values
+true,0,0,q,0.5~.m.di.0email.colornormalize[0f;10f;5f],1,1,colornormalize 5 on 0-10 scale is 0.5
+true,0,0,q,0f~.m.di.0email.colornormalize[0f;10f;-1f],1,1,colornormalize clamps below min to 0f
+true,0,0,q,1f~.m.di.0email.colornormalize[0f;10f;11f],1,1,colornormalize clamps above max to 1f
+
+/ Test 32: colorhsv2rgb converts hue-saturation-value to 3-byte rgb
+run,0,0,q,rgb:.m.di.0email.colorhsv2rgb[0f;1f;1f],1,1,convert pure red hsv to rgb
+true,0,0,q,3=count rgb,1,1,colorhsv2rgb returns 3 byte values
+true,0,0,q,rgb[0]=max rgb,1,1,colorhsv2rgb red hue has maximum red channel
+run,0,0,q,mono:.m.di.0email.colorizemono[`red;0f;100f;0 50 100f],1,1,colorize 3 values on red scale
+true,0,0,q,3=count mono,1,1,colorizemono returns one entry per input value
+true,0,0,q,all 3=count each mono,1,1,colorizemono each entry is 3 bytes


### PR DESCRIPTION
# Email

`email.q` provides a self-contained HTML email module. It supports two transports: the system `sendmail` utility, or SMTP via `curl`. HTML construction utilities are ported from [qmail](https://github.com/BestiaPL/qmail).

Alert and report result handlers compatible with the TorQ reporter process are included, ported from `code/processes/reporter.q`.

## Requirements

One of the following must be installed and configured:

- **sendmail via msmtp** — lightweight sendmail replacement. Used when no `smtpurl` is configured. See [Sendmail setup (msmtp)](#sendmail-setup-msmtp) below.
- **curl** — used when `smtpurl` is set in config. Most systems have this by default.

## Sendmail setup (msmtp)

`msmtp` is the recommended sendmail transport. It acts as a drop-in `sendmail` replacement and routes mail through an SMTP relay.

### 1. Install

```bash
sudo apt install msmtp msmtp-mta
```

`msmtp-mta` creates the `/usr/sbin/sendmail` symlink that the module uses.

### 2. Configure

Create `~/.msmtprc`:

```
defaults
auth           on
tls            on
tls_trust_file /etc/ssl/certs/ca-certificates.crt
logfile        ~/.msmtp.log

account        default
host           smtp.gmail.com
port           587
from           me@example.com
user           me@example.com
password       myapppassword
```

Set permissions (msmtp refuses to run if the file is world-readable):

```bash
chmod 600 ~/.msmtprc
```

For Gmail, `password` must be an [App Password](https://myaccount.google.com/apppasswords) — not your account password. App Passwords require 2-Step Verification to be enabled on the account.

### 3. Test outside q

```bash
echo -e "To: me@example.com\nSubject: test\n\ntest body" | sendmail me@example.com
cat ~/.msmtp.log
```

A successful send logs `exitcode=EX_OK`. If it fails, the log contains the SMTP error.

### 4. Test from q

```q
email:use`di.email
log:use`di.log
log.init[logconfig]
logdep:`info`warn`error!(log.info;log.warn;log.error)

email.init[
  `mailfrom`enabled!("me@example.com";1b);
  `log`send!(logdep;::)]

email.test[`$"me@example.com"]
```

## Configuration

Passed as the first dictionary to `init`. All keys are optional.

| Key | Type | Default | Description |
|---|---|---|---|
| `mailfrom` | string or symbol | `"torq@localhost"` | From address on outgoing emails |
| `enabled` | boolean | `0b` | Set `1b` to allow emails to be sent |
| `smtpurl` | string or symbol | `""` | SMTP server URL e.g. `"smtp://smtp.gmail.com:587"`. When set, curl is used instead of sendmail |
| `smtpuser` | string or symbol | `""` | SMTP username |
| `smtppassword` | string | `""` | SMTP password |
| `smtpssl` | boolean | `1b` | Require TLS (`--ssl-reqd`). Set `0b` to disable |

## Dependencies

Passed as the second dictionary to `init`. Pass `(::)` to use all defaults.

| Key | Required | Type | Description |
|---|---|---|---|
| `` `log `` | yes | dict | Logger with keys `` `info`warn`error ``, each `{[c;m]}`. Required — `init` throws if absent. See `di.log` for a default implementation. |
| `` `send `` | no | function | `{[frm;to;sub;body;att]}` — injectable send function. Pass `(::)` or omit to use curl smtp when `smtpurl` is set, otherwise sendmail. |

## Core Structures

- **`history`** (table, `.z.M`) — Append-only log of every `senddefault` call:
  - `time` (timestamp), `recipients` (symbol), `subject` (any), `status` (symbol: `` `sent `` / `` `failed `` / `` `disabled ``), `bytes` (long: `0j` on success, `-1j` on failure or disabled)
- **`alertstats`** (keyed table, `.z.M`) — Tracks last alert send time per `procname`+`alertname` pair for cooldown enforcement

## Main Functions

### `init`
Parameters: `[config; deps]`

Initialises the module. Pass `(::)` for config to use defaults (email disabled, sendmail transport). A `log` dependency is always required — `init` throws if it is absent.

When `smtpurl` is set in config and no custom `send` is injected, the curl SMTP transport is used automatically.

### `senddefault`
Parameters: `[msgdict]`

Sends an HTML email. `msgdict` keys:
- `to` — symbol or symbol list of recipients
- `subject` — string
- `body` — list of strings (plain strings are wrapped in a styled `<p>` tag; pre-built HTML strings are passed through as-is; a timestamp footer is appended automatically)
- `attachment` — (optional) hsym file path

Returns `1b` on success, `0b` on send failure, `-1` if disabled. Every attempt is logged to `history`.

### `test`
Parameters: `[to]`

Sends a test email to `to` (symbol). Returns `1b` on success.

### `alert`
Parameters: `[period; recipients]`

Returns a result handler projection `{[data]}` for the TorQ reporter `resulthandler` column.

- `period` — timespan cooldown e.g. `00:02:00`
- `recipients` — string or list of strings (email addresses)
- `data.result` must have a `messages` column (list of strings)

### `report`
Parameters: `[temppath; recipients; filename; filetype]`

Returns a result handler projection `{[data]}` for the TorQ reporter `resulthandler` column. Writes result to `temppath/filename.filetype`, emails it as an attachment, then deletes the temp file.

### `getstatus`
Returns the full `history` table.

## HTML Helpers

These functions are exported and can be used to build rich HTML email bodies before passing to `senddefault`.

| Function | Parameters | Description |
|---|---|---|
| `addtext` | `[text]` | Wrap a string in a styled `<p>` tag |
| `mailheading` | `[level; text]` | Heading `<h1>`–`<h4>` |
| `mailbold` | `[text]` | Bold text |
| `mailitalic` | `[text]` | Italic text |
| `mailtable` | `[t]` | Render a q table as an HTML table |
| `ztable` | `[t]` | Table with alternating row colours |
| `maildict` | `[d]` | Render a q dict as an HTML table |
| `zdict` | `[d]` | Dict table with alternating row colours |
| `addcolor` | `[color; text]` | Apply font colour |
| `mailbgcolor` | `[hex; text]` | Apply background colour |
| `mailsize` | `[px; text]` | Set font size in pixels |
| `mailcolors` | `[color; bg; size; text]` | Combined colour/background/size |
| `mailurl` | `[url; text]` | Hyperlink |

## Usage Examples

Every example requires a logger. Define one before calling `init`:

```q
logdep:`info`warn`error!(
  {[c;m] -1 "INFO  [",string[c],"] ",m;};
  {[c;m] -1 "WARN  [",string[c],"] ",m;};
  {[c;m] -2 "ERROR [",string[c],"] ",m;});
```

### 1. Send a plain email via sendmail

```q
email:use`di.email
email.init[
  `mailfrom`enabled!("me@example.com";1b);
  `log`send!(logdep;::)]
email.senddefault`to`subject`body!(`$"ops@example.com";"Deployed";enlist"Build 42 deployed.")
```

### 2. Send via SMTP

```q
email:use`di.email
email.init[
  `mailfrom`enabled`smtpurl`smtpuser`smtppassword!(
    "me@example.com";
    1b;
    "smtp://smtp.gmail.com:587";
    "me@example.com";
    "myapppassword");
  `log`send!(logdep;::)]
email.senddefault`to`subject`body!(`$"ops@example.com";"Deployed";enlist"Build 42 deployed.")
```

### 3. Send an HTML table

```q
email:use`di.email
email.init[
  `mailfrom`enabled!("me@example.com";1b);
  `log`send!(logdep;::)]
results:([]sym:`AAPL`GOOG;price:182.5 141.3)
body:email.ztable[results]
email.senddefault`to`subject`body!(`$"ops@example.com";"EOD Prices";body)
```

### 4. Test transport connectivity

```q
email:use`di.email
email.init[
  `mailfrom`enabled!("me@example.com";1b);
  `log`send!(logdep;::)]
email.test[`$"me@example.com"]
```

### 5. Use as a reporter alert handler

```
rdbmemorycheck|.checks.memorycheck[1500000000]|email.alert[00:02;getenv`DEMOEMAILRECEIVER]|||rdb|rdb1|00:00:00|23:59:59|00:05:00|00:00:20|0 1 2 3 4 5 6
```

### 6. Use as a reporter report handler

```
eodreport|hloc[.proc.cd[];.proc.cd[];0D01]|email.report[getenv[`TORQHOME];getenv`DEMOEMAILRECEIVER;"eodreport";"csv"]|||rdb||18:00|18:00|00:00|00:05|2 3 4 5 6
```

### 7. Testing with a mock send function

```q
mocklog:`info`warn`error!({[c;m]};{[c;m]};{[c;m]})
mocksend:{[frm;to;sub;body;att]}
email:use`di.email
email.init[
  `mailfrom`enabled!("me@example.com";1b);
  `log`send!(mocklog;mocksend)]
email.senddefault`to`subject`body!(`$"a@b.com";"test";enlist"hello")
```
