### PR TITLE
Rename usage to querylog

### DIFF
--- a/di/querylog/init.q
+++ b/di/querylog/init.q
@@ -1,4 +1,4 @@
 //Load core functionality into root module namespace
-\l ::usage.q
+\l ::querylog.q
 
 export:([init;getusage;readlog;flushusage;setextension;clearextension])

--- a/di/querylog/querylog.md
+++ b/di/querylog/querylog.md
@@ -1,4 +1,4 @@
-# `usage.q` – External Usage Logging for kdb+
+# `querylog.q` – External Usage Logging for kdb+
 
 A utility library for logging external queries and connections to a kdb+ session. It captures metadata such as execution time, memory usage, user information, command content, and errors.
 
@@ -19,7 +19,7 @@ A utility library for logging external queries and connections to a kdb+ session
 
 ## :label: Usage Table Schema
 
-Logs are stored in a table `usage` with the following columns:
+Logs are stored in a table `querylog` with the following columns:
 
 | Column | Type      | Description                               |
 |--------|-----------|-------------------------------------------|
@@ -98,13 +98,13 @@ handlers and initiates the in memory logs/ on disk logs if enabled.
 
 ## :memo: Log File Output
 
-- Log files are created as: `usage_{logname}_{timestamp}.log`
-- Format: pipe-delimited strings with same columns as `usage`
+- Log files are created as: `querylog_{logname}_{timestamp}.log`
+- Format: pipe-delimited strings with same columns as `querylog`
 
 Use `readlog` to parse logs from disk:
 
 ```q
-usage.readlog["logs/usage_rdb_2025.06.25.log"]
+querylog.readlog["logs/querylog_rdb_2025.06.25.log"]
 ```
 
 ---
@@ -114,7 +114,7 @@ usage.readlog["logs/usage_rdb_2025.06.25.log"]
 | Function               | Description                                                                                       |
 |------------------------|---------------------------------------------------------------------------------------------------|
 | `flushusage[t]` | Remove records older than `t` (timespan) ago from memory                                          |
-| `ext[x]`        | Optional extension hook for each record written (`x` is a list of column data for `usage`) |
+| `ext[x]`        | Optional extension hook for each record written (`x` is a list of column data for `querylog`) |
 | `nextid[]`      | Generate next usage ID                                                                            |
 | `meminfo[]`     | Get partial system memory stats                                                                   |
 | `formatarg`     | Format incoming `.z` argument for logging                                                         |
@@ -146,17 +146,17 @@ Default handlers will be defined if not previously set.
 ## :test_tube: Example
 
 ```q
-// Include usage module in a process
-usage: use `di.usage
+// Include querylog module in a process
+querylog: use `di.querylog
 
 // View dictionary of functions
-usage
+querylog
 
-// Initialise usage and set up logging to disk and memory by passing a dictionary to init function
-usage.init[`localtime`logdir`logname`logtodisk`logtomemory`ignorelist!(1b;"logs";"rdb";1b;1b;(`upd; ".hb.checkheartbeat[]"))]
+// Initialise querylog and set up logging to disk and memory by passing a dictionary to init function
+querylog.init[`localtime`logdir`logname`logtodisk`logtomemory`ignorelist!(1b;"logs";"rdb";1b;1b;(`upd; ".hb.checkheartbeat[]"))]
 
-// Check usage table for synchronous user queries
-select from usage.getusage[] where zcmd=`pg
+// Check querylog table for synchronous user queries
+select from querylog.getusage[] where zcmd=`pg
 time                          id  extime               zcmd status a          u     w  cmd                                                                   mem                           sz  error
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 2025.07.04D11:57:59.474947647 194                      pg   b      2130706433 kdbNoob 14 "tables[]"                                                            8273600 67108864 67108864 0 0     ""

--- a/di/querylog/querylog.md
+++ b/di/querylog/querylog.md
@@ -46,7 +46,7 @@ by providing a dictionary of the variable name and desired value (default values
 ```q
 localtime    : 1b                   // Log using local time or UTC (default: 1b, local)
 logdir       : "/path/to/logs";     // Path to log directory
-logname      : "rdb";               // Identifier used in log file name: usage_{logname}_{timestamp}.log
+logname      : "rdb";               // Identifier used in log file name: querylog_{logname}_{timestamp}.log
 logtimestamp : {.z.Z};              // Function to give log name timestamp suffix (default: {[] :.z.D;})
 logtodisk    : 1b;                  // Log to disk (default: 0b)
 logtomemory  : 1b;                  // Log to memory table (default: 1b)

--- a/di/querylog/querylog.q
+++ b/di/querylog/querylog.q
@@ -3,7 +3,7 @@
 / handlers with usage-logging wrappers of their current definitions
 
 / table to store usage info
-usage:([]
+querylog:([]
   time:`timestamp$();
   id:`long$();
   extime:`timespan$();
@@ -35,7 +35,7 @@ logh:0;
 / write a query log message
 write:{[x]
   if[logtodisk;@[neg logh;"|"sv .Q.s1 each x;()]];
-  if[logtomemory;.z.M.usage upsert x];
+  if[logtomemory;.z.M.querylog upsert x];
   ext x;
   };
 
@@ -49,24 +49,24 @@ setextension:{[fn].z.m.ext:fn};
 clearextension:{.z.m.ext:{[x]}};
 
 // Flush out in-memory usage records older than flushtime
-flushusage:{[flushtime] delete from .z.M.usage where time<.z.m.currenttime[.z.m.localtime]-flushtime;}
+flushusage:{[flushtime] delete from .z.M.querylog where time<.z.m.currenttime[.z.m.localtime]-flushtime;}
 
 // Create usage log on disk
 createlog:{[logdir;logname;timestamp]
-  basename:"usage_",logname,"_",string[timestamp],".log";
+  basename:"querylog_",logname,"_",string[timestamp],".log";
   / close the current log handle if there is one
   @[hclose;logh;()];
   / open the file
   .z.m.logh:hopen hsym`$logdir,"/",basename;
   };
 
-/ parse a usage log file and return as a usage table
+/ parse a querylog log file and return as a querylog table
 readlog:{[filename]
   / remove leading backtick from symbol columns, drop "i" suffix from a and w columns and cast back to integers
   :update
     zcmd:`$1_'string zcmd,u:`$1_'string u,a:"I"$-1_'a,w:"I"$-1_'w
     from
-    @[{update "J"$'" "vs'mem from flip(cols usage)!("PJNSC*S***J*";"|")0: x};
+    @[{update "J"$'" "vs'mem from flip(cols querylog)!("PJNSC*S***J*";"|")0: x};
       hsym`$filename;
       {'"failed to read log file : ",x}];
   };
@@ -172,18 +172,18 @@ initlog:{[]
       '"logname and logdir must be set to enable on disk usage logging. logToDisk disabled"];
     .[createlog;
       (logdir;logname;logtimestamp localtime);
-      {.z.m.logtodisk:0b;'"Error creating log file: ",logdir,"/usage_",logname,"_",string[logtimestamp localtime]," | Error: ",x}]];
+      {.z.m.logtodisk:0b;'"Error creating log file: ",logdir,"/querylog_",logname,"_",string[logtimestamp localtime]," | Error: ",x}]];
   };
 
-/ exportable function to get usage table
-getusage:{usage};
+/ exportable function to get querylog table
+getusage:{querylog};
 
 init:{[configs]
   / default configuration values and flags
   .z.m.logtodisk:0b;    / whether to log to disk
   .z.m.logtomemory:1b;  / whether to log to memory
   .z.m.logdir:"";       / should be set before loading library to initialise on disk logging
-  .z.m.logname:"";      / log file will take the form "usage_{logname}_{date/time}.log"
+  .z.m.logname:"";      / log file will take the form "querylog_{logname}_{date/time}.log"
   .z.m.ignore:1b;       / whether to check the ignore list for function calls to not log
   .z.m.ignorelist:();   / list of function to not log usage of
   .z.m.level:3;         / log level,	0 = nothing, 1 = errors only, 2 = + open, close, queries, 3 = + log queries before execution

--- a/di/querylog/querylog.q
+++ b/di/querylog/querylog.q
@@ -126,7 +126,7 @@ logquery:{[zcmd;handler;arg]
   :logafter[id;zcmd;currenttime localtime;@[handler;arg;logerror[id;zcmd;currenttime localtime;arg;start;]];arg;start:currenttime localtime];
   };
 
-/ log before and after query execution is attempted, filtering with .usage.ignoreList
+/ log before and after query execution is attempted, filtering with .querylog.ignorelist
 logqueryfiltered:{[zcmd;handler;arg]
   if[ignore;
     if[0h=type arg;

--- a/di/querylog/querylog.q
+++ b/di/querylog/querylog.q
@@ -126,7 +126,7 @@ logquery:{[zcmd;handler;arg]
   :logafter[id;zcmd;currenttime localtime;@[handler;arg;logerror[id;zcmd;currenttime localtime;arg;start;]];arg;start:currenttime localtime];
   };
 
-/ log before and after query execution is attempted, filtering with .querylog.ignorelist
+/ log before and after query execution is attempted, filtering with querylog.ignorelist
 logqueryfiltered:{[zcmd;handler;arg]
   if[ignore;
     if[0h=type arg;

--- a/di/querylog/test.csv
+++ b/di/querylog/test.csv
@@ -1,9 +1,9 @@
 action,ms,bytes,lang,code,repeat,minver,comment
 
-before,0,0,q,usage:use`di.usage,1,,Initialize module
+before,0,0,q,querylog:use`di.querylog,1,,Initialize module
 
 before,0,0,q,.test.resethandlers:{.z.pw:{[x;y] 1b}; .z.po:{}; .z.pc:{}; .z.wo:{}; .z.wc:{}; .z.ws:{neg[.z.w] x}; .z.pg:{value x}; .z.ps:{value x}; .z.pp:{}; .z.exit:{};},1,1,funtion to reset handles to default
-before,0,0,q,.test.clearusage:{.m.di.0usage.usage:0#.m.di.0usage.usage},1,1,function to clear usage table
+before,0,0,q,.test.clearusage:{.m.di.0querylog.querylog:0#.m.di.0querylog.querylog},1,1,function to clear usage table
 
 before,0,0,q,.test.handlers: (`pw`po`pc`wo`wc`ws`pg`ps`ph`pp`exit),1,1,modified handlers
 before,0,0,q,.test.customtracker:([]zcmd:`symbol$(); args:()),1,1,table to track custom handlers arguments
@@ -11,7 +11,7 @@ before,0,0,q,.test.resetcustomtracker:{.test.customtracker:0#.test.customtracker
 before,0,0,q,.test.setcustomhandler:{[handler]handler set {[zcmd;args] `.test.customtracker upsert (zcmd;args)}[handler;];},1,1,funtion to apply custom functionality to handlers
 before,0,0,q,.test.custompasshandler:{[handler]handler set {[zcmd;user;pass] `.test.customtracker upsert (zcmd;(user;pass))}[handler;;];},1,1,funtion to apply custom .z.pw handler
 
-run,0,0,q,usage.init[],1,1,testing out-of-the-box logging configuration
+run,0,0,q,querylog.init[],1,1,testing out-of-the-box logging configuration
 run,0,0,q,.z.pw[`test_user;"pass123"],1,1,run args against each handle
 run,0,0,q,.z.po 1i,1,1,
 run,0,0,q,.z.pc 2i,1,1,
@@ -24,14 +24,14 @@ run,0,0,q,.z.pp (.j.j`x`y`z!(1;"http%3a%2f%2fdomain.com";`post);`hdr1`hdr2!("hel
 run,0,0,q,.z.exit 0,1,1,
 run,0,0,q,.z.ps:{},1,1,swollow web socket response
 run,0,0,q,.z.ws -8!"1+1",1,1,
-true,0,0,q,(count .test.handlers) = count select distinct zcmd from usage.getusage[] where zcmd in .test.handlers,1,1,all handles must be logged at least once
+true,0,0,q,(count .test.handlers) = count select distinct zcmd from querylog.getusage[] where zcmd in .test.handlers,1,1,all handles must be logged at least once
 run,0,0,q,.test.resethandlers[],1,1,restore default handles
 run,0,0,q,.test.clearusage[],1,1,clear usage table
 
 run,0,0,q,.test.resetcustomtracker[],1,1,clear custom tracker in case of test rerun
 run,0,0,q,.test.setcustomhandler each .Q.dd[`.z] each .test.handlers,1,1,run with custom handlers and verify that they are wrapped and properly invoked after running usage.init
 run,0,0,q,.test.custompasshandler `.z.pw,1,1,
-run,0,0,q,usage.init[],1,1,initialize usage to wrap custom handlers
+run,0,0,q,querylog.init[],1,1,initialize usage to wrap custom handlers
 run,0,0,q,.z.pw[`test_user;"pass123"],1,1,run args against each handle
 run,0,0,q,.z.po 1i,1,1,
 run,0,0,q,.z.pc 2i,1,1,
@@ -45,58 +45,58 @@ run,0,0,q,.z.exit 255,1,1,
 run,0,0,q,.z.ps:{},1,1,swollow web socket response
 run,0,0,q,.z.ws -8!"1+1",1,1,
 true,0,0,q,([]zcmd:`.z.pw`.z.po`.z.pc`.z.wo`.z.wc`.z.pg`.z.ps`.z.ph`.z.pp`.z.exit`.z.ws;args:((`test_user;"pass123");1i;2i;3i;4i;"1+1";(+;2;2);"dummy";"dummy";255;-8!"1+1"))~.test.customtracker,1,1, all handles/args must be logged in custom tracker table
-true,0,0,q,(count .test.handlers) = count select distinct zcmd from usage.getusage[] where zcmd in .test.handlers,1,1,all handles must be logged at least once in main usage table
+true,0,0,q,(count .test.handlers) = count select distinct zcmd from querylog.getusage[] where zcmd in .test.handlers,1,1,all handles must be logged at least once in main usage table
 run,0,0,q,.test.resethandlers[],1,1,restore default handles
 run,0,0,q,.test.clearusage[],1,1,clear usage table
 
-true,0,0,q,@[usage.init;(enlist `logtodisk)!(enlist 1b);::]~"logname and logdir must be set to enable on disk usage logging. logToDisk disabled",1,1,testing diffren log configs / should error on invalid logging configurations
-true,0,0,q,@[usage.init;(`logtodisk`logdir`logname)!(1b;".";"");::]~"logname and logdir must be set to enable on disk usage logging. logToDisk disabled",1,1,
-true,0,0,q,@[usage.init;(`logtodisk`logdir`logname)!(1b;"";"test");::]~"logname and logdir must be set to enable on disk usage logging. logToDisk disabled",1,1,
+true,0,0,q,@[querylog.init;(enlist `logtodisk)!(enlist 1b);::]~"logname and logdir must be set to enable on disk usage logging. logToDisk disabled",1,1,testing diffren log configs / should error on invalid logging configurations
+true,0,0,q,@[querylog.init;(`logtodisk`logdir`logname)!(1b;".";"");::]~"logname and logdir must be set to enable on disk usage logging. logToDisk disabled",1,1,
+true,0,0,q,@[querylog.init;(`logtodisk`logdir`logname)!(1b;"";"test");::]~"logname and logdir must be set to enable on disk usage logging. logToDisk disabled",1,1,
 run,0,0,q,.test.resethandlers[],1,1,restore default handles
 run,0,0,q,.test.clearusage[],1,1,clear usage table
 
-run,0,0,q,.test.defaultcreatelog:.m.di.0usage.createlog,1,1,
-run,0,0,q,.m.di.0usage.createlog:{z;'"some error"},1,1,should fail if log file creation errors
-true,0,0,q,@[usage.init;(`logtodisk`logdir`logname)!(1b;".";"test");::]like"Error creating log file: ./usage_test_* | Error: some error",1,1,
-run,0,0,q,.m.di.0usage.createlog:.test.defaultcreatelog,1,1, default value
+run,0,0,q,.test.defaultcreatelog:.m.di.0querylog.createlog,1,1,
+run,0,0,q,.m.di.0querylog.createlog:{z;'"some error"},1,1,should fail if log file creation errors
+true,0,0,q,@[querylog.init;(`logtodisk`logdir`logname)!(1b;".";"test");::]like"Error creating log file: ./querylog_test_* | Error: some error",1,1,
+run,0,0,q,.m.di.0querylog.createlog:.test.defaultcreatelog,1,1, default value
 run,0,0,q,.test.resethandlers[],1,1,restore default handles
 run,0,0,q,.test.clearusage[],1,1,clear usage table
 
-run,0,0,q,@[system;"rm usage_test_* 2> /dev/null";::];,1,1,clean up in case of previous run
-run,0,0,q,usage.init[(`logtodisk`logdir`logname)!(1b;".";"test")],1,1,test correctly write to and read from log file
+run,0,0,q,@[system;"rm querylog_test_* 2> /dev/null";::];,1,1,clean up in case of previous run
+run,0,0,q,querylog.init[(`logtodisk`logdir`logname)!(1b;".";"test")],1,1,test correctly write to and read from log file
 run,0,0,q,.z.po 1i,1,1,
 run,0,0,q,.z.pg "1+1",1,1,
 run,0,0,q,.z.pg (avg;1 2 3),1,1,
 run,0,0,q,.z.pc 1i,1,1,
-true,0,0,q,usage.getusage[] ~ usage.readlog first system"ls usage_test_*",1,1,
-run,0,0,q,system"rm usage_test_*",1,1,remove usage log file
+true,0,0,q,querylog.getusage[] ~ querylog.readlog first system"ls querylog_test_*",1,1,
+run,0,0,q,system"rm querylog_test_*",1,1,remove usage log file
 run,0,0,q,.test.resethandlers[],1,1,restore default handles
 run,0,0,q,.test.clearusage[],1,1,clear usage table
 
-run,0,0,q,usage.init[(enlist `level)!(enlist 0)],1,1,test loging at different levels
+run,0,0,q,querylog.init[(enlist `level)!(enlist 0)],1,1,test loging at different levels
 run,0,0,q,.z.po 1i,1,1,
 run,0,0,q,.z.pg"1+1",1,1,
 run,0,0,q,.t.pg:.z.pg,1,1,
 fail,0,0,q,.z.pg"1+`a",1,1,
 run,0,0,q,.z.pc 1i,1,1,
-true,0,0,q,0=count usage.getusage[],1,1,
+true,0,0,q,0=count querylog.getusage[],1,1,
 run,0,0,q,.test.resethandlers[],1,1,restore default handles
 run,0,0,q,.test.clearusage[],1,1,clear usage table
-run,0,0,q,usage.init[(enlist `level)!(enlist 1)],1,1,log errors only
+run,0,0,q,querylog.init[(enlist `level)!(enlist 1)],1,1,log errors only
 run,0,0,q,.z.po 1i,1,1,
 run,0,0,q,.z.pg"1+1",1,1,
 fail,0,0,q,.z.pg"1+`a",1,1,
 run,0,0,q,.z.pc 1i,1,1,
-true,0,0,q,(1=count usage.getusage[])&usage.getusage[][0;`zcmd`status`cmd`error]~(`pg;"e";"1+`a";"type"),1,1,
+true,0,0,q,(1=count querylog.getusage[])&querylog.getusage[][0;`zcmd`status`cmd`error]~(`pg;"e";"1+`a";"type"),1,1,
 run,0,0,q,.test.resethandlers[],1,1,restore default handles
 run,0,0,q,.test.clearusage[],1,1,clear usage table
-run,0,0,q,usage.init[(enlist `level)!(enlist 2)],1,1,log open/close/queries (no "before" queries)
+run,0,0,q,querylog.init[(enlist `level)!(enlist 2)],1,1,log open/close/queries (no "before" queries)
 run,0,0,q,.z.ps"1+1",1,1,
-run,0,0,q,(1=count usage.getusage[])&usage.getusage[][0;`zcmd`status`cmd]~(`ps;"c";"1+1"),1,1,
+run,0,0,q,(1=count querylog.getusage[])&querylog.getusage[][0;`zcmd`status`cmd]~(`ps;"c";"1+1"),1,1,
 run,0,0,q,.test.resethandlers[],1,1,restore default handles
 run,0,0,q,.test.clearusage[],1,1,clear usage table
 
-run,0,0,q,usage.init[(`ignore`ignorelist)!(1b;(`upd;"0+0"))],1,1,test ignore list logging
+run,0,0,q,querylog.init[(`ignore`ignorelist)!(1b;(`upd;"0+0"))],1,1,test ignore list logging
 run,0,0,q,upd:{y;},1,1,upd function for testing
 run,0,0,q,fn:{y;},1,1,additional function for testing
 run,0,0,q,.z.ps(+;1;2),1,1,not ignored
@@ -104,13 +104,13 @@ run,0,0,q,.z.ps(`upd;`trade;([]x:1 2)),1,1,ignored
 run,0,0,q,.z.ps(`fn;`trade;([]x:1 2)),1,1,not ignored
 run,0,0,q,.z.ps"0+0",1,1,ignored
 run,0,0,q,.z.ps"1+0",1,1,not ignored
-true,0,0,q,([]zcmd:`ps;status:6#"bc";cmd:(.Q.s1(+;1;2);.Q.s1(`fn;`trade;([]x:1 2));"1+0")where 3#2)~`zcmd`status`cmd#usage.getusage[],1,1,
+true,0,0,q,([]zcmd:`ps;status:6#"bc";cmd:(.Q.s1(+;1;2);.Q.s1(`fn;`trade;([]x:1 2));"1+0")where 3#2)~`zcmd`status`cmd#querylog.getusage[],1,1,
 run,0,0,q,.test.resethandlers[],1,1,restore default handles
 run,0,0,q,.test.clearusage[],1,1,default value
 
-run,0,0,q,usage.init[],1,1,test extension functionality
+run,0,0,q,querylog.init[],1,1,test extension functionality
 run,0,0,q,.test.ext:(),1,1,set to be empty in case of test rerun
-run,0,0,q,"usage.setextension[{.test.ext,:enlist x}]",1,1,
+run,0,0,q,"querylog.setextension[{.test.ext,:enlist x}]",1,1,
 run,0,0,q,.z.pw[`test_user;"pass123"],1,1,run args against each handle
 run,0,0,q,.z.po 1i,1,1,
 run,0,0,q,.z.pc 2i,1,1,
@@ -119,32 +119,32 @@ run,0,0,q,.z.wc 4i,1,1,
 run,0,0,q,.z.ps:{},1,1,
 run,0,0,q,.z.ws -8!"1+1",1,1,
 run,0,0,q,.test.resethandlers[],1,1,
-run,0,0,q,usage.init[],1,1,re-initialize message handlers
+run,0,0,q,querylog.init[],1,1,re-initialize message handlers
 run,0,0,q,.z.pg"1+1",1,1,
 run,0,0,q,.z.ps(+;2;2),1,1,
 run,0,0,q,.z.ph(.j.j`x`y`z!(1;"http%3a%2f%2fdomain.com";`get);`hdr1`hdr2!("hello";"goodbye")),1,1,
 run,0,0,q,.z.pp(.j.j`x`y`z!(1;"http%3a%2f%2fdomain.com";`post);`hdr1`hdr2!("hello";"goodbye")),1,1,
 run,0,0,q,.z.exit 0,1,1,
-true,0,0,q,usage.getusage[]~flip key[flip usage.getusage[]]!flip .test.ext,1,1,
+true,0,0,q,querylog.getusage[]~flip key[flip querylog.getusage[]]!flip .test.ext,1,1,
 run,0,0,q,.test.resethandlers[],1,1,
 run,0,0,q,.test.clearusage[],1,1,
-run,0,0,q,usage.clearextension[],1,1,reset extesnion function to default
+run,0,0,q,querylog.clearextension[],1,1,reset extesnion function to default
 
-run,0,0,q,usage.init[],1,1,test flushusage function
-run,0,0,q,.m.di.0usage.usage:([]id:1 1 2 2 3;time:2025.07.24+0D12 0D12:00:00.1 0D12:01:59.999999999 0D12:02 0D12:05),1,1,test flush usage table fucntion
-run,0,0,q,.m.di.0usage.currenttime:{2025.07.24D12:07}
-run,0,0,q,usage.flushusage 0D00:05,1,1,
-true,0,0,q,usage.getusage[]~([]id:2 3;time:2025.07.24+0D12:02 0D12:05),1,1,
-run,0,0,q,usage.flushusage 5D,1,1,nop
-true,0,0,q,usage.getusage[]~([]id:2 3;time:2025.07.24+0D12:02 0D12:05),1,1,
-run,0,0,q,usage.flushusage 0,1,1,wipe
-true,0,0,q,0=count usage.getusage[],1,1,
-run,0,0,q,usage.flushusage 0D00:01,1,1,no effect on empty table
-true,0,0,q,0=count usage.getusage[],1,1,
-run,0,0,q,.m.di.0usage.currenttime:{[local] $[local;.z.P;.z.p]};,1,1,re define currenttime function
-run,0,0,q,.m.di.0usage.usage: ([] time:`timestamp$(); id:`long$(); extime:`timespan$(); zcmd:`symbol$(); status:`char$(); a:`int$(); u:`symbol$(); w:`int$(); cmd:(); mem:(); sz:`long$(); error:()),1,1,
+run,0,0,q,querylog.init[],1,1,test flushusage function
+run,0,0,q,.m.di.0querylog.querylog:([]id:1 1 2 2 3;time:2025.07.24+0D12 0D12:00:00.1 0D12:01:59.999999999 0D12:02 0D12:05),1,1,test flush usage table fucntion
+run,0,0,q,.m.di.0querylog.currenttime:{2025.07.24D12:07}
+run,0,0,q,querylog.flushusage 0D00:05,1,1,
+true,0,0,q,querylog.getusage[]~([]id:2 3;time:2025.07.24+0D12:02 0D12:05),1,1,
+run,0,0,q,querylog.flushusage 5D,1,1,nop
+true,0,0,q,querylog.getusage[]~([]id:2 3;time:2025.07.24+0D12:02 0D12:05),1,1,
+run,0,0,q,querylog.flushusage 0,1,1,wipe
+true,0,0,q,0=count querylog.getusage[],1,1,
+run,0,0,q,querylog.flushusage 0D00:01,1,1,no effect on empty table
+true,0,0,q,0=count querylog.getusage[],1,1,
+run,0,0,q,.m.di.0querylog.currenttime:{[local] $[local;.z.P;.z.p]};,1,1,re define currenttime function
+run,0,0,q,.m.di.0querylog.querylog: ([] time:`timestamp$(); id:`long$(); extime:`timespan$(); zcmd:`symbol$(); status:`char$(); a:`int$(); u:`symbol$(); w:`int$(); cmd:(); mem:(); sz:`long$(); error:()),1,1,
 run,0,0,q,.test.resethandlers[],1,1,
 run,0,0,q,.test.clearusage[],1,1,
 
-run,0,0,q,usage.init[(enlist `test)!enlist 1b],1,1,pass a non config var to init
-fail,0,0,q,key .m.di.0usage.test,1,1,
+run,0,0,q,querylog.init[(enlist `test)!enlist 1b],1,1,pass a non config var to init
+fail,0,0,q,key .m.di.0querylog.test,1,1,

--- a/di/querylog/test.csv
+++ b/di/querylog/test.csv
@@ -29,7 +29,7 @@ run,0,0,q,.test.resethandlers[],1,1,restore default handles
 run,0,0,q,.test.clearusage[],1,1,clear usage table
 
 run,0,0,q,.test.resetcustomtracker[],1,1,clear custom tracker in case of test rerun
-run,0,0,q,.test.setcustomhandler each .Q.dd[`.z] each .test.handlers,1,1,run with custom handlers and verify that they are wrapped and properly invoked after running usage.init
+run,0,0,q,.test.setcustomhandler each .Q.dd[`.z] each .test.handlers,1,1,run with custom handlers and verify that they are wrapped and properly invoked after running querylog.init
 run,0,0,q,.test.custompasshandler `.z.pw,1,1,
 run,0,0,q,querylog.init[],1,1,initialize usage to wrap custom handlers
 run,0,0,q,.z.pw[`test_user;"pass123"],1,1,run args against each handle


### PR DESCRIPTION
<img width="1065" height="1254" alt="image" src="https://github.com/user-attachments/assets/1d57b694-55ba-4eb5-bc1a-2bb329117368" />

  - Renamed di/usage/ directory to di/querylog/ and renamed usage.q/usage.md to querylog.q/querylog.md
  - Updated all internal references from usage to querylog across module code and tests
  - Updated documentation and examples in querylog.md to reflect the new naming