### PR TITLE
KDB-X enable the review agent via yaml file

### DIFF
--- a/.reviewagent.yml
+++ b/.reviewagent.yml
@@ -1,0 +1,6 @@
+enabled: true
+
+tracker:
+  enabled: true
+  provider: trello
+  project_key: KDB-X


### PR DESCRIPTION
Enabling the DI review agent for this repository, Trello won't work unless PR requests include KDB-X in branch and/or commit names. Will look into enforcing this format.