### PR TITLE
Feature toml

### DIFF
--- a/di/toml/init.q
+++ b/di/toml/init.q
@@ -1,4 +1,4 @@
-// a small scoped-down TOML parser for the modular torq world - reads settings .toml files into
-// q dicts. pure module (no init, no injected deps); di.config lazily loads it to parse .toml tiers.
+/ a small scoped-down TOML parser for the modular torq world - reads settings .toml files into
+/ q dicts. pure module (no init, no injected deps); di.config lazily loads it to parse .toml tiers.
 \l ::toml.q
 export:([parsetoml;parsefile;getapimeta])

--- a/di/toml/init.q
+++ b/di/toml/init.q
@@ -1,0 +1,4 @@
+// a small scoped-down TOML parser for the modular torq world - reads settings .toml files into
+// q dicts. pure module (no init, no injected deps); di.config lazily loads it to parse .toml tiers.
+\l ::toml.q
+export:([parsetoml;parsefile;getapimeta])

--- a/di/toml/test.csv
+++ b/di/toml/test.csv
@@ -69,6 +69,10 @@ comment,,,,,,,parsefile (fail loud on missing; callers guard existence themselve
 true,0,0,q,""":appdb""~(tml.parsefile TDIR,""/x.toml"")`dir",1,1,parsefile reads and parses a .toml file
 true,0,0,q,"100j~(tml.parsefile TDIR,""/x.toml"")`rows",1,1,parsefile parses an integer as a long
 fail,0,0,q,"tml.parsefile TDIR,""/nope.toml""",1,1,a missing .toml file SIGNALS (fail loud; a cascade caller guards existence itself)
+comment,,,,,,,di.depcheck deps.toml contract - [dependencies] table of quoted dotted keys -> version strings
+true,0,0,q,expdeps~(tml.parsetoml fdeps)`dependencies,1,1,a deps.toml [dependencies] table parses to the symbol!version-string dict di.depcheck readdeps expects
+true,0,0,q,11h=type key (tml.parsetoml fdeps)`dependencies,1,1,dependency names are symbols (quoted dotted keys unquoted)
+true,0,0,q,all 10h=type each value (tml.parsetoml fdeps)`dependencies,1,1,version values stay strings (policy-free) for meetsmin comparison
 comment,,,,,,,getapimeta
 true,0,0,q,"(asc (key tml) except `getapimeta)~asc exec name from tml.getapimeta[]",1,1,getapimeta documents exactly the callable exports (plumbing omitted)
 true,0,0,q,not `getapimeta in exec name from tml.getapimeta[],1,1,getapimeta does not register itself (plumbing not in the api)

--- a/di/toml/test.csv
+++ b/di/toml/test.csv
@@ -1,0 +1,63 @@
+action,ms,bytes,lang,code,repeat,minver,comment
+before,0,0,q,tml:use`di.toml,1,1,load the module
+before,0,0,q,"system ""l di/toml/test.q""",1,1,load TOML text fixtures + temp-file helpers
+before,0,0,q,setuptoml[],1,1,write a temp .toml file fixture
+before,0,0,q,rflat:tml.parsetoml fflat,1,1,parse the flat fixture once
+before,0,0,q,rcom:tml.parsetoml fcomments,1,1,parse the comments fixture once
+before,0,0,q,rsec:tml.parsetoml fsection,1,1,parse the section fixture once
+before,0,0,q,rarr:tml.parsetoml farrays,1,1,parse the arrays fixture once
+comment,,,,,,,scalars - types and policy-free strings
+true,0,0,q,1j~rflat`a,1,1,integer parses to a long
+true,0,0,q,-7h=type rflat`a,1,1,integer is a long (matches .q value semantics) not an int
+true,0,0,q,2.5~rflat`b,1,1,float parses to a float
+true,0,0,q,1b~rflat`c,1,1,true parses to a boolean
+true,0,0,q,0b~rflat`d,1,1,false parses to a boolean
+true,0,0,q,"""hello""~rflat`s",1,1,quoted string parses to its contents
+true,0,0,q,10h=type rflat`s,1,1,string stays a q char string (policy-free - never a symbol)
+comment,,,,,,,quoted keys
+true,0,0,q,"42j~(tml.parsetoml fqkey)(`$""my key"")",1,1,a double-quoted key with a space is preserved
+comment,,,,,,,comments (whole-line + trailing + quote-aware)
+true,0,0,q,1j~rcom`a,1,1,a trailing comment is stripped from a value
+true,0,0,q,"""a # b""~rcom`s",1,1,a # inside a string is NOT treated as a comment
+true,0,0,q,`a`s~asc key rcom,1,1,a whole-line comment produces no spurious key
+comment,,,,,,,sections (one level of nesting)
+true,0,0,q,1j~rsec`top,1,1,a key before any section stays at the top level
+true,0,0,q,99h=type rsec`sec,1,1,a section becomes a sub-dict
+true,0,0,q,10j~rsec[`sec]`k,1,1,a section key is parsed
+true,0,0,q,"""rdb""~rsec[`sec]`name",1,1,a section string value is a q string
+comment,,,,,,,arrays
+true,0,0,q,1 2 3~rarr`nums,1,1,an integer array parses to a long vector
+true,0,0,q,"(""xx"";""yy"")~rarr`strs",1,1,a string array parses to a list of strings
+true,0,0,q,0=count rarr`empty,1,1,an empty array parses to an empty list
+comment,,,,,,,escapes
+true,0,0,q,expesc~(tml.parsetoml fescapes)`s,1,1,the \n \t \" escapes are expanded
+true,0,0,q,7=count (tml.parsetoml fescapes)`s,1,1,the unescaped string has the expected length
+comment,,,,,,,blank / comment-only input
+true,0,0,q,0=count tml.parsetoml fblank,1,1,blank and comment-only input yields an empty dict
+comment,,,,,,,fail-loud - unparseable / unsupported input signals (shared utility - never silent garbage)
+fail,0,0,q,"tml.parsetoml ""novalue""",1,1,a line with no = signals a clear error
+fail,0,0,q,"tml.parsetoml ""d = 2024-01-15""",1,1,a datetime value is rejected (out of scope - would be a silent null)
+fail,0,0,q,"tml.parsetoml ""name = rdb""",1,1,a bare unquoted word value is rejected (quote real strings)
+fail,0,0,q,"tml.parsetoml ""a.b = 1""",1,1,an unquoted dotted key is rejected (nesting not supported)
+fail,0,0,q,"tml.parsetoml ""[[x]]\ny = 1""",1,1,array-of-tables [[...]] is rejected (not supported)
+fail,0,0,q,"tml.parsetoml ""[x\ny = 1""",1,1,a malformed section header (missing ]) is rejected
+fail,0,0,q,"tml.parsetoml ""[""",1,1,a bare [ gives a clean signal (not a cryptic 'type)
+fail,0,0,q,tml.parsetoml 5,1,1,a non-char-string input signals rather than a cryptic error
+true,0,0,q,"1j~(tml.parsetoml ""x = 1"")`x",1,1,a normal multi-char string still parses
+fail,0,0,q,"tml.parsetoml ""[]\nk = 1""",1,1,an empty section name is rejected
+fail,0,0,q,"tml.parsetoml ""export FOO=5""",1,1,a non-TOML line with = and a valid value still fails (invalid bare key - has a space)
+fail,0,0,q,"tml.parsetoml ""x:a=5""",1,1,another non-TOML-with-= line fails (bare key has a colon)
+fail,0,0,q,"tml.parsetoml ""= 5""",1,1,an empty key is rejected
+fail,0,0,q,"tml.parsetoml ""a = 1\na = 2""",1,1,a duplicate key is rejected (TOML error - not silent last-wins)
+fail,0,0,q,"tml.parsetoml ""[s]\nx = 1\n[s]\ny = 2""",1,1,a duplicate section is rejected
+true,0,0,q,"1j~(tml.parsetoml ""my-key_2 = 1"")(`$""my-key_2"")",1,1,a bare key with - and _ is valid (TOML allows them)
+true,0,0,q,"1j~(tml.parsetoml fqdotkey)(`$""a.b"")",1,1,a QUOTED key with a dot is a literal key (allowed - not a dotted-key construct)
+comment,,,,,,,parsefile (fail loud on missing; callers guard existence themselves)
+true,0,0,q,""":appdb""~(tml.parsefile TDIR,""/x.toml"")`dir",1,1,parsefile reads and parses a .toml file
+true,0,0,q,"100j~(tml.parsefile TDIR,""/x.toml"")`rows",1,1,parsefile parses an integer as a long
+fail,0,0,q,"tml.parsefile TDIR,""/nope.toml""",1,1,a missing .toml file SIGNALS (fail loud; a cascade caller guards existence itself)
+comment,,,,,,,getapimeta
+true,0,0,q,"(asc (key tml) except `getapimeta)~asc exec name from tml.getapimeta[]",1,1,getapimeta documents exactly the callable exports (plumbing omitted)
+true,0,0,q,not `getapimeta in exec name from tml.getapimeta[],1,1,getapimeta does not register itself (plumbing not in the api)
+true,0,0,q,`name`public`descrip`params`return~cols tml.getapimeta[],1,1,getapimeta rows carry the registry columns
+after,0,0,q,teardowntoml[],1,1,remove the temp fixture dir

--- a/di/toml/test.csv
+++ b/di/toml/test.csv
@@ -10,6 +10,8 @@ comment,,,,,,,scalars - types and policy-free strings
 true,0,0,q,1j~rflat`a,1,1,integer parses to a long
 true,0,0,q,-7h=type rflat`a,1,1,integer is a long (matches .q value semantics) not an int
 true,0,0,q,2.5~rflat`b,1,1,float parses to a float
+true,0,0,q,"1000f~(tml.parsetoml ""x = 1e3"")`x",1,1,an exponent float (1e3) parses to a float
+true,0,0,q,"-0.02~(tml.parsetoml ""x = -2E-2"")`x",1,1,a signed exponent float (-2E-2) parses to a float
 true,0,0,q,1b~rflat`c,1,1,true parses to a boolean
 true,0,0,q,0b~rflat`d,1,1,false parses to a boolean
 true,0,0,q,"""hello""~rflat`s",1,1,quoted string parses to its contents
@@ -19,6 +21,7 @@ true,0,0,q,"42j~(tml.parsetoml fqkey)(`$""my key"")",1,1,a double-quoted key wit
 comment,,,,,,,comments (whole-line + trailing + quote-aware)
 true,0,0,q,1j~rcom`a,1,1,a trailing comment is stripped from a value
 true,0,0,q,"""a # b""~rcom`s",1,1,a # inside a string is NOT treated as a comment
+true,0,0,q,expescq~(tml.parsetoml fescq)`d,1,1,an escaped quote in a value plus a trailing comment is handled (escape-aware quote tracking)
 true,0,0,q,`a`s~asc key rcom,1,1,a whole-line comment produces no spurious key
 comment,,,,,,,sections (one level of nesting)
 true,0,0,q,1j~rsec`top,1,1,a key before any section stays at the top level
@@ -29,9 +32,11 @@ comment,,,,,,,arrays
 true,0,0,q,1 2 3~rarr`nums,1,1,an integer array parses to a long vector
 true,0,0,q,"(""xx"";""yy"")~rarr`strs",1,1,a string array parses to a list of strings
 true,0,0,q,0=count rarr`empty,1,1,an empty array parses to an empty list
+true,0,0,q,expescarr~(tml.parsetoml fescarr)`a,1,1,an escaped quote in an array element does not mis-split the comma (escape-aware splitcommas)
 comment,,,,,,,escapes
 true,0,0,q,expesc~(tml.parsetoml fescapes)`s,1,1,the \n \t \" escapes are expanded
 true,0,0,q,7=count (tml.parsetoml fescapes)`s,1,1,the unescaped string has the expected length
+true,0,0,q,exptab~(tml.parsetoml ftab)`s,1,1,a literal tab inside a string value is preserved (not converted to a space by trimming)
 true,0,0,q,expbs~(tml.parsetoml fbs)`p,1,1,an escaped backslash next to n resolves to backslash+n (single-pass unescape) not a newline
 true,0,0,q,0=count (tml.parsetoml femptystr)`k,1,1,a quoted empty string is a valid empty value
 fail,0,0,q,tml.parsetoml finvesc,1,1,an unknown string escape (\x) is rejected
@@ -45,6 +50,9 @@ fail,0,0,q,"tml.parsetoml ""d = 2024-01-15""",1,1,a datetime value is rejected (
 fail,0,0,q,"tml.parsetoml ""name = rdb""",1,1,a bare unquoted word value is rejected (quote real strings)
 fail,0,0,q,"tml.parsetoml ""a.b = 1""",1,1,an unquoted dotted key is rejected (nesting not supported)
 fail,0,0,q,"tml.parsetoml ""[[x]]\ny = 1""",1,1,array-of-tables [[...]] is rejected (not supported)
+fail,0,0,q,"tml.parsetoml ""[a.b]\nx = 1""",1,1,a dotted (nested) section name is rejected (same rule as dotted keys)
+fail,0,0,q,"tml.parsetoml ""[a b]\nx = 1""",1,1,an invalid bare section name (has a space) is rejected
+true,0,0,q,"1j~(tml.parsetoml fqsec)[`$""a.b""]`x",1,1,a QUOTED section name is a literal name (unquoted like a quoted key)
 fail,0,0,q,"tml.parsetoml ""[x\ny = 1""",1,1,a malformed section header (missing ]) is rejected
 fail,0,0,q,"tml.parsetoml ""[""",1,1,a bare [ gives a clean signal (not a cryptic 'type)
 fail,0,0,q,tml.parsetoml 5,1,1,a non-char-string input signals rather than a cryptic error

--- a/di/toml/test.csv
+++ b/di/toml/test.csv
@@ -32,6 +32,11 @@ true,0,0,q,0=count rarr`empty,1,1,an empty array parses to an empty list
 comment,,,,,,,escapes
 true,0,0,q,expesc~(tml.parsetoml fescapes)`s,1,1,the \n \t \" escapes are expanded
 true,0,0,q,7=count (tml.parsetoml fescapes)`s,1,1,the unescaped string has the expected length
+true,0,0,q,expbs~(tml.parsetoml fbs)`p,1,1,an escaped backslash next to n resolves to backslash+n (single-pass unescape) not a newline
+true,0,0,q,0=count (tml.parsetoml femptystr)`k,1,1,a quoted empty string is a valid empty value
+fail,0,0,q,tml.parsetoml finvesc,1,1,an unknown string escape (\x) is rejected
+fail,0,0,q,"tml.parsetoml ""k =""",1,1,an empty (missing) value is rejected
+fail,0,0,q,"tml.parsetoml ""x = [1, 2""",1,1,an unterminated array (no closing ]) is rejected
 comment,,,,,,,blank / comment-only input
 true,0,0,q,0=count tml.parsetoml fblank,1,1,blank and comment-only input yields an empty dict
 comment,,,,,,,fail-loud - unparseable / unsupported input signals (shared utility - never silent garbage)

--- a/di/toml/test.q
+++ b/di/toml/test.q
@@ -15,6 +15,13 @@ fbs:"p = \"a\\\\nb\"";                      / TOML  p = "a\\nb"  (escaped backsl
 expbs:"a\\nb";                              / expected: a, backslash, n, b (4 chars) - NOT a newline
 femptystr:"k = \"\"";                       / TOML  k = ""  (a legitimate empty string)
 finvesc:"s = \"a\\xb\"";                    / TOML  s = "a\xb"  (\x is not a valid escape)
+fescq:"d = \"a\\\"b\" # c";                 / TOML  d = "a\"b" # c  (escaped quote in value + comment)
+expescq:"a\"b";                             / expected value of d: a, ", b  (comment stripped)
+fescarr:"a = [\"x\\\"y\", \"zz\"]";         / TOML  a = ["x\"y", "zz"]  (escaped quote in an array elem)
+expescarr:("x\"y";"zz");                    / expected: two elements x"y and zz (comma not mis-split)
+fqsec:"[\"a.b\"]\nx = 1";                   / TOML  ["a.b"]  -  a QUOTED section name (dot is literal)
+ftab:"s = \"x\ty\"";                        / TOML  s = "x<tab>y"  (a literal tab inside the string)
+exptab:"x\ty";                              / expected: x, tab, y - the tab preserved, not spaced
 
 TDIR:"/tmp/ditomltest";
 setuptoml:{[] system "mkdir -p ",TDIR; (`$":",TDIR,"/x.toml") 0: ("dir = \":appdb\"";"rows = 100");};

--- a/di/toml/test.q
+++ b/di/toml/test.q
@@ -22,6 +22,8 @@ expescarr:("x\"y";"zz");                    / expected: two elements x"y and zz 
 fqsec:"[\"a.b\"]\nx = 1";                   / TOML  ["a.b"]  -  a QUOTED section name (dot is literal)
 ftab:"s = \"x\ty\"";                        / TOML  s = "x<tab>y"  (a literal tab inside the string)
 exptab:"x\ty";                              / expected: x, tab, y - the tab preserved, not spaced
+fdeps:"# peer deps\n[dependencies]\n\"di.servers\" = \"0.3.0\"  # injected\n\"di.dbwrite\" = \"0.1.0\"";  / a di.depcheck deps.toml
+expdeps:`di.servers`di.dbwrite!("0.3.0";"0.1.0");   / di.depcheck's readdeps expects [dependencies] -> symbol!version-string
 
 TDIR:"/tmp/ditomltest";
 setuptoml:{[] system "mkdir -p ",TDIR; (`$":",TDIR,"/x.toml") 0: ("dir = \":appdb\"";"rows = 100");};

--- a/di/toml/test.q
+++ b/di/toml/test.q
@@ -11,6 +11,10 @@ fescapes:"s = \"a\\nb\\tc\\\"d\"";
 fblank:"\n  \n# only a comment\n";
 fqdotkey:"\"a.b\" = 1";                     / a QUOTED key with a dot - a literal key, allowed
 expesc:"a\nb\tc\"d";                        / expected unescaped value of fescapes' s
+fbs:"p = \"a\\\\nb\"";                      / TOML  p = "a\\nb"  (escaped backslash then n)
+expbs:"a\\nb";                              / expected: a, backslash, n, b (4 chars) - NOT a newline
+femptystr:"k = \"\"";                       / TOML  k = ""  (a legitimate empty string)
+finvesc:"s = \"a\\xb\"";                    / TOML  s = "a\xb"  (\x is not a valid escape)
 
 TDIR:"/tmp/ditomltest";
 setuptoml:{[] system "mkdir -p ",TDIR; (`$":",TDIR,"/x.toml") 0: ("dir = \":appdb\"";"rows = 100");};

--- a/di/toml/test.q
+++ b/di/toml/test.q
@@ -1,0 +1,17 @@
+/ di.toml test fixtures (loaded by test.csv). di.toml is pure - no mocks needed; the TOML text is
+/ defined here as q string literals (far cleaner than CSV-escaping all the quotes inline) plus a
+/ small temp .toml file fixture for parsefile.
+
+fflat:"a = 1\nb = 2.5\nc = true\nd = false\ns = \"hello\"";
+fqkey:"\"my key\" = 42";
+fcomments:"# whole line\na = 1  # trailing\ns = \"a # b\"  # real comment";
+fsection:"top = 1\n[sec]\nk = 10\nname = \"rdb\"";
+farrays:"nums = [1, 2, 3]\nstrs = [\"xx\", \"yy\"]\nempty = []";
+fescapes:"s = \"a\\nb\\tc\\\"d\"";
+fblank:"\n  \n# only a comment\n";
+fqdotkey:"\"a.b\" = 1";                     / a QUOTED key with a dot - a literal key, allowed
+expesc:"a\nb\tc\"d";                        / expected unescaped value of fescapes' s
+
+TDIR:"/tmp/ditomltest";
+setuptoml:{[] system "mkdir -p ",TDIR; (`$":",TDIR,"/x.toml") 0: ("dir = \":appdb\"";"rows = 100");};
+teardowntoml:{[] system "rm -rf ",TDIR;};

--- a/di/toml/toml.md
+++ b/di/toml/toml.md
@@ -73,6 +73,8 @@ wrong data:
 - a **dotted key** `a.b` (nesting) — but a *quoted* dotted key `"a.b" = 1` is a legitimate literal
   key and is kept
 - a **duplicate key / section** (or a key/section-name clash) — a TOML error, not silent last-wins
+- an **empty (missing) value** `k =`, and an **unterminated / malformed array** (`[` without a `]`)
+- an **unknown or dangling string escape** (`\x`, a trailing `\`)
 - an **array-of-tables** `[[x]]`, a malformed section header (missing `]`), or an empty section name
 - a non-char input, or a 1-char input (a char atom) — handled/validated at the `parsetoml` entry so
   it never surfaces as a cryptic `'type`
@@ -82,12 +84,11 @@ gets a clear `'di.toml: …'` error, not quiet garbage.
 
 ## Known limitations
 
-- **Escape handling is sequential** (`ssr`-based, `\\` applied last). A literal backslash immediately
-  followed by an escape character (e.g. a TOML value containing `\\n`) is an accepted edge — it is
-  not disambiguated the way a single-pass unescaper would. Real settings values don't hit this.
 - **Comment/`=` detection uses raw quote parity, not escape-aware.** A line that combines an
-  *escaped* quote inside a string with a trailing `#` comment on the same line can mis-detect the
-  comment boundary. Whole strings and whole-line/trailing comments (the common cases) are fine.
+  *escaped* quote inside a string value with a trailing `#` comment on the same line (e.g.
+  `d = "a\"b" # c`) can mis-detect the comment/separator boundary. This **fails safe** — the line is
+  *rejected* (signals), never silently mis-parsed — so it is over-strict on a rare construct, not a
+  correctness hole. Whole strings and whole-line/trailing comments (the common cases) are fine.
 - **Integer/float detection is by presence of `.`**, so an exponent-only float (`1e3`) is rejected
   (it parses to a null and signals) — write `1.0e3`.
 

--- a/di/toml/toml.md
+++ b/di/toml/toml.md
@@ -47,10 +47,10 @@ array-of-tables (`[[x]]`).
 | `parsefile` | `parsefile[path]` | Read and parse a `.toml` file into a dict. A **missing file signals** — a caller that treats missing as acceptable (a config cascade) guards existence itself first (as di.config does). |
 | `getapimeta` | `getapimeta[]` | This module's api metadata — one row per **callable** function (`parsetoml`, `parsefile`); `getapimeta` itself is plumbing and is deliberately not listed. For `di.torq` to register with `di.api`. |
 
-Export is conservative — the internal helpers (`trimstr`, `firstunquoted`, `stripcomment`,
-`splitassign`, `unquotekey`, `unescape`, `parsescalar`, `splitcommas`, `parsevalue`, `sectname`,
-`addkv`, `addline`) are not exported. No `version` export / `VERSION` file yet — deferred to the
-di.depcheck rollout, as in di.config/di.servers.
+Export is conservative — the internal helpers (`trimstr`, `isquoted`, `instrmask`, `firstunquoted`,
+`stripcomment`, `splitassign`, `unquotekey`, `parsekey`, `unescape`, `parsescalar`, `splitcommas`,
+`parsevalue`, `sectname`, `addkv`, `addline`) are not exported. No `version` export / `VERSION` file yet — deferred
+to the di.depcheck rollout, as in di.config/di.servers.
 
 ## di.config integration contract
 
@@ -66,16 +66,17 @@ Anything the scoped grammar can't correctly represent **signals** rather than si
 wrong data:
 
 - a bare/unquoted non-numeric value (a word, a datetime)
-- an **invalid bare key** — one with a space, `:`, or any char outside `A-Za-z0-9_-` (this is what
-  makes most *non-TOML* lines that happen to contain `=` — a shell `export FOO=5`, a q `x:a=5` —
-  fail loud instead of parsing to a bogus symbol key)
-- an **empty key** (`= 5`)
-- a **dotted key** `a.b` (nesting) — but a *quoted* dotted key `"a.b" = 1` is a legitimate literal
-  key and is kept
+- an **invalid bare key or section name** — one with a space, `:`, or any char outside `A-Za-z0-9_-`
+  (this is what makes most *non-TOML* lines that happen to contain `=` — a shell `export FOO=5`, a q
+  `x:a=5` — fail loud instead of parsing to a bogus symbol key). Keys and section names are held to
+  the *same* rule (a shared `parsekey`)
+- an **empty key or section name** (`= 5`, `[]`)
+- a **dotted key or section** (`a.b`, `[a.b]` — nesting) — but a *quoted* `"a.b"` (key or section) is
+  a legitimate literal name and is kept, unquoted
 - a **duplicate key / section** (or a key/section-name clash) — a TOML error, not silent last-wins
 - an **empty (missing) value** `k =`, and an **unterminated / malformed array** (`[` without a `]`)
 - an **unknown or dangling string escape** (`\x`, a trailing `\`)
-- an **array-of-tables** `[[x]]`, a malformed section header (missing `]`), or an empty section name
+- an **array-of-tables** `[[x]]`, or a malformed section header (missing `]`)
 - a non-char input, or a 1-char input (a char atom) — handled/validated at the `parsetoml` entry so
   it never surfaces as a cryptic `'type`
 
@@ -84,13 +85,10 @@ gets a clear `'di.toml: …'` error, not quiet garbage.
 
 ## Known limitations
 
-- **Comment/`=` detection uses raw quote parity, not escape-aware.** A line that combines an
-  *escaped* quote inside a string value with a trailing `#` comment on the same line (e.g.
-  `d = "a\"b" # c`) can mis-detect the comment/separator boundary. This **fails safe** — the line is
-  *rejected* (signals), never silently mis-parsed — so it is over-strict on a rare construct, not a
-  correctness hole. Whole strings and whole-line/trailing comments (the common cases) are fine.
-- **Integer/float detection is by presence of `.`**, so an exponent-only float (`1e3`) is rejected
-  (it parses to a null and signals) — write `1.0e3`.
+None that mis-parse. Everything outside the supported grammar — including TOML number forms not
+covered (underscored `1_000`, hex/octal/binary `0x`/`0o`/`0b`, `inf`/`nan`) — is **rejected with a
+clear signal**, never silently mis-parsed. The scope is deliberately the settings-file subset; widen
+it (and add tests) if a real settings file needs more.
 
 ## Tests
 

--- a/di/toml/toml.md
+++ b/di/toml/toml.md
@@ -1,0 +1,105 @@
+# di.toml
+
+A small, scoped-down TOML parser for the modular TorQ world. It reads settings `.toml` files (and
+in-memory TOML text) into q dicts. Its reason for existing is to back di.config's `.toml`
+resolution tier — di.config lazily loads di.toml only when a `.toml` file is actually parsed.
+
+**Pure module** — no `init`, no logger, no injected dependencies. di.config invokes it *during
+config resolution*, before any logger exists, so parse errors are **signalled** with a clear
+`'di.toml: …'` message rather than logged.
+
+**Fail-loud** — because this is a *shared* utility (any module that parses a file may use it),
+di.toml never silently returns nulls or garbage for input it can't correctly handle: a missing
+file, an unparseable value (bare word / datetime), a dotted key, or a malformed/array-of-tables
+section header all **signal**. A caller that treats a *missing file* as acceptable (a config
+cascade probing optional tiers) must **guard existence itself** before calling — the way di.config
+does (`if[0=count key hsym`$path; :()!()]`) — di.toml does not paper over it.
+
+## Scope (v1)
+
+Supported — what real settings files need:
+
+- `key = value` pairs; keys bare or double-quoted (`"my key" = 1`)
+- `#` comments, whole-line or trailing — **quote-aware**, so a `#` inside a `"…"` string is not a
+  comment
+- one level of `[section]` nesting — a section becomes a **sub-dict** keyed by the section name
+- scalar values: double-quoted strings (`\"` `\\` `\n` `\t` escapes), integers, floats,
+  `true`/`false`, and flat arrays of any of those
+
+Deliberately **not** supported (out of scope for settings): nested inline tables (`{a=1,b=2}`),
+dotted keys (`a.b.c`), single-quoted literal strings, multi-line strings, datetimes, and
+array-of-tables (`[[x]]`).
+
+## Type policy
+
+- **Strings are policy-free.** TOML has no symbol type, so every TOML string parses to a q **char
+  string** (`10h`), never a symbol. Callers that want a symbol coerce at the point of use (`` `$ ``
+  is a no-op on an already-a-symbol value, so the same consumer code works for `.q` settings too).
+  This is the contract di.config and its consumers rely on.
+- **Integers parse to `long`** (matching what `value` gives a `.q` settings line like `rows:100`),
+  floats to `float`, `true`/`false` to `boolean`.
+
+## Exported functions
+
+| Function | Signature | Description |
+|---|---|---|
+| `parsetoml` | `parsetoml[text]` | Parse a TOML string into a dict (one level of `[section]` nesting). Blank and comment-only lines contribute nothing. |
+| `parsefile` | `parsefile[path]` | Read and parse a `.toml` file into a dict. A **missing file signals** — a caller that treats missing as acceptable (a config cascade) guards existence itself first (as di.config does). |
+| `getapimeta` | `getapimeta[]` | This module's api metadata — one row per **callable** function (`parsetoml`, `parsefile`); `getapimeta` itself is plumbing and is deliberately not listed. For `di.torq` to register with `di.api`. |
+
+Export is conservative — the internal helpers (`trimstr`, `firstunquoted`, `stripcomment`,
+`splitassign`, `unquotekey`, `unescape`, `parsescalar`, `splitcommas`, `parsevalue`, `sectname`,
+`addkv`, `addline`) are not exported. No `version` export / `VERSION` file yet — deferred to the
+di.depcheck rollout, as in di.config/di.servers.
+
+## di.config integration contract
+
+di.config's `parsefile` delegates a `.toml` path via `` (use`di.toml)[`parsefile] path ``, expecting
+a **flat dict** of `setting → value` back (section values are sub-dicts). This module satisfies that
+directly. Once di.toml is on `QPATH` alongside di.config, the `.toml` half of di.config's cascade
+(and `.toml > .q` within a tier) works, and di.config's guard-rail error (`the di.toml module was
+not found on QPATH`) no longer fires.
+
+## Out-of-scope constructs are rejected, not mis-parsed
+
+Anything the scoped grammar can't correctly represent **signals** rather than silently producing
+wrong data:
+
+- a bare/unquoted non-numeric value (a word, a datetime)
+- an **invalid bare key** — one with a space, `:`, or any char outside `A-Za-z0-9_-` (this is what
+  makes most *non-TOML* lines that happen to contain `=` — a shell `export FOO=5`, a q `x:a=5` —
+  fail loud instead of parsing to a bogus symbol key)
+- an **empty key** (`= 5`)
+- a **dotted key** `a.b` (nesting) — but a *quoted* dotted key `"a.b" = 1` is a legitimate literal
+  key and is kept
+- a **duplicate key / section** (or a key/section-name clash) — a TOML error, not silent last-wins
+- an **array-of-tables** `[[x]]`, a malformed section header (missing `]`), or an empty section name
+- a non-char input, or a 1-char input (a char atom) — handled/validated at the `parsetoml` entry so
+  it never surfaces as a cryptic `'type`
+
+This is what makes di.toml safe as a shared parser — a consumer feeding a richer or malformed file
+gets a clear `'di.toml: …'` error, not quiet garbage.
+
+## Known limitations
+
+- **Escape handling is sequential** (`ssr`-based, `\\` applied last). A literal backslash immediately
+  followed by an escape character (e.g. a TOML value containing `\\n`) is an accepted edge — it is
+  not disambiguated the way a single-pass unescaper would. Real settings values don't hit this.
+- **Comment/`=` detection uses raw quote parity, not escape-aware.** A line that combines an
+  *escaped* quote inside a string with a trailing `#` comment on the same line can mis-detect the
+  comment boundary. Whole strings and whole-line/trailing comments (the common cases) are fine.
+- **Integer/float detection is by presence of `.`**, so an exponent-only float (`1e3`) is rejected
+  (it parses to a null and signals) — write `1.0e3`.
+
+## Tests
+
+```q
+k4unit:use`di.k4unit
+k4unit.moduletest`di.toml
+```
+
+`test.csv` (+ `test.q` fixtures) covers scalars and their types, policy-free strings, quoted keys,
+quote-aware comments, one-level sections, arrays (int/string/empty), the `\n`/`\t`/`\"` escapes,
+blank/comment-only input, a missing `=` signalling, `parsefile` (present + missing file), and
+`getapimeta`. TOML text lives in `test.q` as q string literals (cleaner than CSV-escaping the quotes
+inline). Runs from the repo root (`test.q` is loaded relative).

--- a/di/toml/toml.q
+++ b/di/toml/toml.q
@@ -11,15 +11,35 @@
 
 keychars:.Q.a,.Q.A,.Q.n,"_-";   / chars allowed in a bare key; anything else must be "quoted"
 
-trimstr:{[s] trim ssr[s;"\t";" "]};
+trimstr:{[s] i:where not s in " \t"; $[count i;(first i)_(1+last i)#s;""]};   / strip leading/trailing space+tab; keep internal
 isquoted:{[s] (1<count s) and all (first;last)@\:s="\""};
 unquotekey:{[k] $[isquoted k;1_-1_k;k]};
 stripcomment:{[l] (firstunquoted["#";l])#l};
-sectname:{[l] `$trimstr l 1+til -2+count l};
+
+parsekey:{[raw]
+  / validate + resolve a bare-or-"quoted" key OR section name to a symbol - both follow the same
+  / rule. a bare name is A-Za-z0-9_- only; a "quoted" name takes any chars (a "." is then literal).
+  / empty, dotted-bare (nesting, out of scope), and invalid-bare names all signal.
+  if[0=count raw;'"di.toml: empty key or section name"];
+  if[not isquoted raw;
+    if["." in raw;'"di.toml: dotted keys/sections are not supported (quote the name if the . is literal): ",raw];
+    if[not all raw in keychars;'"di.toml: invalid bare name (only A-Za-z0-9_- allowed; quote otherwise): ",raw]];
+  `$unquotekey raw};
+
+sectname:{[hdr] parsekey trimstr hdr 1+til -2+count hdr};
+
+instrmask:{[s]
+  / per-position boolean: is this char inside a "..." string? escape-aware - a \" or \\ inside a
+  / string does not toggle the state. carries (in-string?; prev-char-was-an-escaping-backslash?) and
+  / returns the state BEFORE each char (0b prepended, last state dropped). used by both scanners
+  / below so comment/= detection and array-comma splitting handle escaped quotes identically.
+  if[0=count s;:0#0b];
+  st:{[a;x] $[a 1;(a 0;0b); x="\\";(a 0;1b); x="\"";(not a 0;0b); (a 0;0b)]}\[(0b;0b);s];
+  0b,-1_ st[;0]};
 
 firstunquoted:{[c;s]
-  / first index of char c outside a "..." span (or count s if none). note: not escape-aware.
-  ?[;1b] (c=s) and not mod[;2] sums s="\""};
+  / first index of char c outside a "..." string (or count s if none); c is only ever "#" or "=".
+  ?[;1b] (s=c) and not instrmask s};
 
 splitassign:{[l]
   / (key;value) split on the first unquoted "=" ; a line with no "=" is malformed.
@@ -38,19 +58,20 @@ unescape:{[s]
   r 0};
 
 parsescalar:{[tok]
-  / one scalar: "quoted string" | true | false | float (has ".") | long. an unquoted non-numeric
-  / token (bare word, datetime) parses to a null and is rejected - real strings must be quoted.
+  / one scalar: "quoted string" | true | false | float (has "." or an e/E exponent) | long. an
+  / unquoted non-numeric token (a bare word, a datetime) parses to a null and is rejected.
   tok:trimstr tok;
   if[isquoted tok;:unescape 1_-1_tok];
   if[tok~"true"; :1b];
   if[tok~"false";:0b];
-  if[null v:$[tok like "*.*";"F"$tok;"J"$tok];
+  if[null v:$[any tok in ".eE";"F"$tok;"J"$tok];
     '"di.toml: unparseable value (quote strings; bare words/datetimes are out of scope): ",tok];
   v};
 
 splitcommas:{[s]
-  / split an array's inner text on top-level commas (a comma inside "..." is not a separator).
-  1_'_[;s] where (s=",") and not mod[;2] sums "\""=s:",",s};
+  / split an array's inner text on top-level commas (a comma inside "..." is not a separator;
+  / escape-aware via instrmask). prepend a comma so the first element uses the same cut-and-drop rule.
+  1_'_[;s] where (s=",") and not instrmask s:",",s};
 
 parsevalue:{[v]
   / a "[ ... ]" array -> list of scalars (empty -> ()); else a single scalar. empty and unterminated
@@ -77,17 +98,12 @@ addline:{[acc;line]
     [hdr:trimstr line;
      if[not "]"=last hdr;'"di.toml: malformed section header (missing ]): ",line];
      if["[["~2 sublist hdr;'"di.toml: array-of-tables [[...]] is not supported: ",line];
-     if[null nm:sectname hdr;'"di.toml: empty section name: ",line];
+     nm:sectname hdr;
      if[not null cursect;top:addkv[top;cursect;sect]];
      (top;nm;()!())];
     [kv:splitassign line;
-     rawkey:kv 0;
-     if[0=count rawkey;'"di.toml: empty key: ",line];
-     if[not isquoted rawkey;
-       if["." in rawkey;'"di.toml: dotted keys are not supported (quote the key if the dot is literal): ",rawkey];
-       if[not all rawkey in keychars;'"di.toml: invalid bare key (only A-Za-z0-9_- allowed; quote otherwise): ",rawkey]];
+     k:parsekey kv 0;
      v:parsevalue kv 1;
-     k:`$unquotekey rawkey;
      $[null cursect;(addkv[top;k;v];cursect;sect);(top;cursect;addkv[sect;k;v])]]]};
 
 parsetoml:{[text]

--- a/di/toml/toml.q
+++ b/di/toml/toml.q
@@ -1,127 +1,83 @@
-/ a small TOML parser for the modular torq world - scoped down for v1 to what real settings files
-/ actually need: key = value pairs (bare or double-quoted keys), whole-line and trailing # comments
-/ (quote-aware, so a "#" inside a string is not a comment), one level of [section] nesting (a
-/ section becomes a sub-dict keyed by the section name), and scalar values - double-quoted strings
-/ (\" \\ \n \t escapes), integers, floats, true/false, and flat arrays of any of those.
-/ deliberately NOT supported: nested inline tables ({a=1,b=2}), dotted keys (a.b.c), single-quoted
-/ literal strings, multi-line strings, datetimes, array-of-tables ([[section]]).
-/ FAIL-LOUD by design (this is a SHARED utility used by many modules, not just di.config): anything
-/ it cannot correctly parse SIGNALS a clear 'di.toml: ...' error rather than silently returning
-/ nulls/garbage - a missing file, a line with no "=", an unparseable value (bare word / datetime),
-/ an invalid bare key (a space/":"/etc. - i.e. most non-TOML lines that happen to contain "="), an
-/ empty key, a dotted key, a duplicate key/section, and a malformed or array-of-tables section
-/ header. a caller that treats a missing file as acceptable (a config cascade probing optional
-/ tiers) must guard existence ITSELF before calling - the way di.config does
-/ (if[0=count key hsym`$path;:()!()]); di.toml does not silently paper over it.
-/ POLICY-FREE strings: every TOML string parses to a q char string (10h), NEVER a symbol (TOML has
-/ no symbol type), so callers coerce with `$ at the point of use. integers parse to LONG (matching
-/ what `value` gives a .q settings line), floats to float.
-/ PURE module: no init, no logger, no injected deps - loaded during config resolution before any
-/ logger exists, so it SIGNALS (does not log).
-/ NOTE (reserved-word trap): q builtins cut/trim/parse/ss/sv/vs/ssr cannot be local names - helpers
-/ are named trimstr/parsetoml/etc.; check `name in .Q.res before reusing a short name.
+/ scoped-down TOML parser for the modular torq world - reads settings .toml files (and text) into a
+/ q dict. supports: key=value (bare or "quoted" keys), quote-aware # comments, one level of [section]
+/ nesting, and scalars (quoted strings, integer->long, float, true/false, flat arrays). not supported:
+/ inline tables, dotted keys, single-quoted/multi-line strings, datetimes, array-of-tables.
+/ fail-loud: anything it cannot correctly parse signals 'di.toml: ...', never silent garbage.
+/ strings parse to q char strings, never symbols (TOML has none) - callers coerce with `$ at use.
+/ pure: no init/logger/deps - di.config loads it during config resolution, before a logger exists.
+/ parsefile signals on a MISSING file; a caller for whom that is acceptable (a cascade probing
+/ optional tiers) guards existence itself first, as di.config does: if[0=count key hsym`$path;:()!()].
+/ reserved-word trap: cut/trim/parse/ss/sv/vs/ssr are builtins - hence trimstr/parsetoml/etc.
 
-/ characters allowed in a bare (unquoted) key - anything else (a space, ":", etc.) must be
-/ double-quoted, so a non-TOML line that happens to contain "=" fails loud instead of parsing to a
-/ bogus symbol key.
-keychars:.Q.a,.Q.A,.Q.n,"_-";
+keychars:.Q.a,.Q.A,.Q.n,"_-";   / chars allowed in a bare key; anything else must be "quoted"
 
-trimstr:{[s]
-  / trim leading/trailing whitespace, treating tabs as spaces.
-  trim ssr[s;"\t";" "]
-  };
-
-isquoted:{[s]
-  / true if s is a double-quoted literal ("...").
-  (1<count s) and all (first;last)@\:s="\""
-  };
+trimstr:{[s] trim ssr[s;"\t";" "]};
+isquoted:{[s] (1<count s) and all (first;last)@\:s="\""};
+unquotekey:{[k] $[isquoted k;1_-1_k;k]};
+stripcomment:{[l] (firstunquoted["#";l])#l};
+sectname:{[l] `$trimstr l 1+til -2+count l};
 
 firstunquoted:{[c;s]
-  / index of the first occurrence of char c in s that is OUTSIDE a double-quoted span, or count s
-  / if none. a running parity of quote characters marks whether each position is inside a string.
-  ?[;1b] (c=s) and not mod[;2] sums s="\""
-  };
-
-stripcomment:{[l]
-  / drop a trailing # comment, but not a "#" that appears inside a "..." string.
-  (firstunquoted["#";l])#l
-  };
+  / first index of char c outside a "..." span (or count s if none). note: not escape-aware.
+  ?[;1b] (c=s) and not mod[;2] sums s="\""};
 
 splitassign:{[l]
-  / split a line on its first unquoted "=" into (key;value), both trimmed. a line with no "=" is a
-  / malformed settings line - signal it (pure module: no logger to route through).
-  eq:firstunquoted["=";l];
-  if[count[l]=eq;'"di.toml: not a key = value line: ",l];
-  trimstr each 0 1_'(0,eq)_l
-  };
-
-unquotekey:{[k]
-  / strip surrounding double-quotes from a key if present; a bare key is returned unchanged.
-  $[isquoted k;1_-1_k;k]
-  };
+  / (key;value) split on the first unquoted "=" ; a line with no "=" is malformed.
+  if[count[l]=eq:firstunquoted["=";l];'"di.toml: not a key = value line: ",l];
+  trimstr each 0 1_'(0,eq)_l};
 
 unescape:{[s]
-  / expand the supported string escapes. applied as sequential replacements (\\ last); a literal
-  / backslash immediately followed by an escape char is an accepted edge (see toml.md).
-  ssr/[s;("\\\"";"\\n";"\\t";"\\\\");("\"";"\n";"\t";"\\")]
-  };
+  / expand \" \\ \n \t in one left-to-right pass, signalling on an unknown or dangling escape. a
+  / single pass (not an ordered ssr-chain) is needed so a \\ next to an escape char resolves right.
+  m:"\"nt\\"!"\"\n\t\\";
+  r:{[m;a;c]
+    $[a 1;[if[not c in key m;'"di.toml: invalid string escape: \\",c];(a[0],m c;0b)];
+      c="\\";(a 0;1b);
+      (a[0],c;0b)]}[m]/[("";0b);s];
+  if[r 1;'"di.toml: dangling backslash in string"];
+  r 0};
 
 parsescalar:{[tok]
-  / parse one scalar token: a double-quoted string (unescaped, kept as a q string), true/false, a
-  / float (has a "."), else a long integer. an unquoted non-numeric token (a bare word, a datetime)
-  / parses to a null and is REJECTED - real strings must be quoted.
+  / one scalar: "quoted string" | true | false | float (has ".") | long. an unquoted non-numeric
+  / token (bare word, datetime) parses to a null and is rejected - real strings must be quoted.
   tok:trimstr tok;
   if[isquoted tok;:unescape 1_-1_tok];
   if[tok~"true"; :1b];
   if[tok~"false";:0b];
-  v:$[tok like "*.*";"F"$tok;"J"$tok];
-  if[null v;'"di.toml: unparseable value (quote strings; bare words/datetimes are out of scope): ",tok];
-  v
-  };
+  if[null v:$[tok like "*.*";"F"$tok;"J"$tok];
+    '"di.toml: unparseable value (quote strings; bare words/datetimes are out of scope): ",tok];
+  v};
 
 splitcommas:{[s]
-  / split a "[...]" array's inner text on TOP-LEVEL commas (a comma inside a quoted element is not
-  / a separator). prepend a comma so the first element is captured by the same cut-and-drop rule.
-  1_'_[;s] where (s=",") and not mod[;2] sums "\""=s:",",s
-  };
+  / split an array's inner text on top-level commas (a comma inside "..." is not a separator).
+  1_'_[;s] where (s=",") and not mod[;2] sums "\""=s:",",s};
 
 parsevalue:{[v]
-  / parse a value: a "[...]" array into a list of scalars (empty array -> ()), an empty value into
-  / an empty string, anything else as a single scalar.
+  / a "[ ... ]" array -> list of scalars (empty -> ()); else a single scalar. empty and unterminated
+  / values are rejected.
   v:trimstr v;
-  if[0=count v;:""];
+  if[0=count v;'"di.toml: missing value"];
   if["["=first v;
+    if[not "]"=last v;'"di.toml: malformed array (must be [ ... ]): ",v];
     inner:trimstr 1_-1_v;
     :$[0=count inner;();parsescalar each splitcommas inner]];
-  parsescalar v
-  };
-
-sectname:{[l]
-  / the section name from a "[name]" header line.
-  `$trimstr l 1+til -2+count l
-  };
+  parsescalar v};
 
 addkv:{[d;k;v]
-  / add key k -> value v to dict d, SIGNALLING on a duplicate - a repeated key, a repeated section,
-  / or a key/section-name clash are all TOML errors and must not silently last-win. catenation (not
-  / ,: in-place) keeps the value list general, so mixing scalar / string / sub-dict / list values
-  / never hits a type-widen error.
+  / add k->v, signalling on a duplicate (a repeated key/section, or a key/section clash - TOML errors).
+  / catenation (not ,:) keeps the value list general so mixed value types never hit a type-widen error.
   if[k in key d;'"di.toml: duplicate key: ",string k];
-  d,(enlist k)!enlist v
-  };
+  d,(enlist k)!enlist v};
 
 addline:{[acc;line]
-  / fold step over the settings lines. acc is (top; cursect; sect): the top-level dict, the current
-  / section name (` before any [section]), and the current section's accumulating dict. a [section]
-  / header flushes the open section into top and opens a fresh one; a key = value goes into the
-  / current section, or into top if no section is open yet. anything malformed signals.
+  / fold step; acc is (top;cursect;sect). a [section] flushes the open section into top and opens a
+  / fresh one; a key=value goes into the current section, or top before any section.
   top:acc 0; cursect:acc 1; sect:acc 2;
   $[(first line)="[";
     [hdr:trimstr line;
      if[not "]"=last hdr;'"di.toml: malformed section header (missing ]): ",line];
      if["[["~2 sublist hdr;'"di.toml: array-of-tables [[...]] is not supported: ",line];
-     nm:sectname line;
-     if[null nm;'"di.toml: empty section name: ",line];
+     if[null nm:sectname hdr;'"di.toml: empty section name: ",line];
      if[not null cursect;top:addkv[top;cursect;sect]];
      (top;nm;()!())];
     [kv:splitassign line;
@@ -129,41 +85,27 @@ addline:{[acc;line]
      if[0=count rawkey;'"di.toml: empty key: ",line];
      if[not isquoted rawkey;
        if["." in rawkey;'"di.toml: dotted keys are not supported (quote the key if the dot is literal): ",rawkey];
-       if[not all rawkey in keychars;'"di.toml: invalid bare key (only A-Za-z0-9_- allowed; quote the key otherwise): ",rawkey]];
-     k:`$unquotekey rawkey;
+       if[not all rawkey in keychars;'"di.toml: invalid bare key (only A-Za-z0-9_- allowed; quote otherwise): ",rawkey]];
      v:parsevalue kv 1;
-     $[null cursect;(addkv[top;k;v];cursect;sect);(top;cursect;addkv[sect;k;v])]]]
-  };
+     k:`$unquotekey rawkey;
+     $[null cursect;(addkv[top;k;v];cursect;sect);(top;cursect;addkv[sect;k;v])]]]};
 
 parsetoml:{[text]
-  / parse TOML text (a single string) into a dict; one level of [section] nesting (a section's dict
-  / is the value of its key). blank and comment-only lines contribute nothing. accepts a char string
-  / (or the char atom q makes of a 1-char literal, normalised to a string); any other type signals -
-  / without this a 1-char input is a char atom and ssr/vs throw a cryptic 'type.
+  / TOML text -> dict (one level of [section] nesting). accepts a string (or the char atom q makes of
+  / a 1-char literal); other types signal - else a 1-char input is an atom and ssr/vs throw 'type.
   if[not 10h=abs type text;'"di.toml: parsetoml expects a char string; got type ",string type text];
-  text:$[10h=type text;text;enlist text];
-  lines:trimstr each stripcomment each "\n" vs text;
-  lines:lines where 0<count each lines;
-  acc:addline/[(()!();`;()!());lines];
-  top:acc 0;
-  if[not null acc 1;top:addkv[top;acc 1;acc 2]];
-  top
-  };
+  lines:trimstr each stripcomment each "\n" vs $[10h=type text;text;enlist text];
+  acc:addline/[(()!();`;()!());lines where 0<count each lines];
+  $[null acc 1;acc 0;addkv[acc 0;acc 1;acc 2]]};
 
 parsefile:{[path]
-  / read and parse a .toml file into a dict. a MISSING file SIGNALS - di.toml fails loud so a caller
-  / that mistypes a path or loses a required file finds out immediately. a caller that treats a
-  / missing file as acceptable (a config cascade probing optional tiers) must guard existence ITSELF
-  / before calling, the way di.config does: if[0=count key hsym`$path;:()!()].
-  fsym:`$":",path;
-  if[0=count key fsym;'"di.toml: file not found: ",path];
-  parsetoml "\n" sv read0 fsym
-  };
+  / read + parse a .toml file. a MISSING file signals (a cascade caller guards existence itself).
+  if[not 10h=abs type path;'"di.toml: parsefile expects a string path"];
+  if[0=count key fsym:`$":",path;'"di.toml: file not found: ",path];
+  parsetoml "\n" sv read0 fsym};
 
 getapimeta:{[]
-  / this module's api metadata, one row per CALLABLE API function, for di.torq to register with
-  / di.api. getapimeta itself is plumbing (di.torq calls it by convention) and is deliberately NOT
-  / listed - the registry describes the callable api, not plumbing. names are bare (di.torq qualifies).
+  / callable-api metadata for di.torq to register with di.api (getapimeta itself is plumbing, omitted).
   :flip `name`public`descrip`params`return!flip(
     (`parsetoml; 1b; "parse TOML text into a dict (one level of section nesting)"; "[string: toml text]"; "dict: setting->value (sections nest)");
     (`parsefile; 1b; "read and parse a .toml file into a dict (signals if missing)"; "[string: file path]"; "dict: setting->value"));

--- a/di/toml/toml.q
+++ b/di/toml/toml.q
@@ -1,75 +1,75 @@
-// a small TOML parser for the modular torq world - scoped down for v1 to what real settings files
-// actually need: key = value pairs (bare or double-quoted keys), whole-line and trailing # comments
-// (quote-aware, so a "#" inside a string is not a comment), one level of [section] nesting (a
-// section becomes a sub-dict keyed by the section name), and scalar values - double-quoted strings
-// (\" \\ \n \t escapes), integers, floats, true/false, and flat arrays of any of those.
-// deliberately NOT supported: nested inline tables ({a=1,b=2}), dotted keys (a.b.c), single-quoted
-// literal strings, multi-line strings, datetimes, array-of-tables ([[section]]).
-// FAIL-LOUD by design (this is a SHARED utility used by many modules, not just di.config): anything
-// it cannot correctly parse SIGNALS a clear 'di.toml: ...' error rather than silently returning
-// nulls/garbage - a missing file, a line with no "=", an unparseable value (bare word / datetime),
-// an invalid bare key (a space/":"/etc. - i.e. most non-TOML lines that happen to contain "="), an
-// empty key, a dotted key, a duplicate key/section, and a malformed or array-of-tables section
-// header. **A caller that treats a missing file as acceptable
-// (a config cascade probing optional tiers) must guard existence ITSELF before calling** - the way
-// di.config does (if[0=count key hsym`$path;:()!()]); di.toml does not silently paper over it.
-// POLICY-FREE strings: every TOML string parses to a q char string (10h), NEVER a symbol (TOML has
-// no symbol type), so callers coerce with `$ at the point of use. integers parse to LONG (matching
-// what `value` gives a .q settings line), floats to float.
-// PURE module: no init, no logger, no injected deps - loaded during config resolution before any
-// logger exists, so it SIGNALS (does not log).
-// NOTE (reserved-word trap): q builtins cut/trim/parse/ss/sv/vs/ssr cannot be local names - helpers
-// are named trimstr/parsetoml/etc.; check `name in .Q.res before reusing a short name.
+/ a small TOML parser for the modular torq world - scoped down for v1 to what real settings files
+/ actually need: key = value pairs (bare or double-quoted keys), whole-line and trailing # comments
+/ (quote-aware, so a "#" inside a string is not a comment), one level of [section] nesting (a
+/ section becomes a sub-dict keyed by the section name), and scalar values - double-quoted strings
+/ (\" \\ \n \t escapes), integers, floats, true/false, and flat arrays of any of those.
+/ deliberately NOT supported: nested inline tables ({a=1,b=2}), dotted keys (a.b.c), single-quoted
+/ literal strings, multi-line strings, datetimes, array-of-tables ([[section]]).
+/ FAIL-LOUD by design (this is a SHARED utility used by many modules, not just di.config): anything
+/ it cannot correctly parse SIGNALS a clear 'di.toml: ...' error rather than silently returning
+/ nulls/garbage - a missing file, a line with no "=", an unparseable value (bare word / datetime),
+/ an invalid bare key (a space/":"/etc. - i.e. most non-TOML lines that happen to contain "="), an
+/ empty key, a dotted key, a duplicate key/section, and a malformed or array-of-tables section
+/ header. a caller that treats a missing file as acceptable (a config cascade probing optional
+/ tiers) must guard existence ITSELF before calling - the way di.config does
+/ (if[0=count key hsym`$path;:()!()]); di.toml does not silently paper over it.
+/ POLICY-FREE strings: every TOML string parses to a q char string (10h), NEVER a symbol (TOML has
+/ no symbol type), so callers coerce with `$ at the point of use. integers parse to LONG (matching
+/ what `value` gives a .q settings line), floats to float.
+/ PURE module: no init, no logger, no injected deps - loaded during config resolution before any
+/ logger exists, so it SIGNALS (does not log).
+/ NOTE (reserved-word trap): q builtins cut/trim/parse/ss/sv/vs/ssr cannot be local names - helpers
+/ are named trimstr/parsetoml/etc.; check `name in .Q.res before reusing a short name.
 
-// characters allowed in a bare (unquoted) key - anything else (a space, ":", etc.) must be
-// double-quoted, so a non-TOML line that happens to contain "=" fails loud instead of parsing to a
-// bogus symbol key.
+/ characters allowed in a bare (unquoted) key - anything else (a space, ":", etc.) must be
+/ double-quoted, so a non-TOML line that happens to contain "=" fails loud instead of parsing to a
+/ bogus symbol key.
 keychars:.Q.a,.Q.A,.Q.n,"_-";
 
 trimstr:{[s]
-  // trim leading/trailing whitespace, treating tabs as spaces.
+  / trim leading/trailing whitespace, treating tabs as spaces.
   trim ssr[s;"\t";" "]
   };
 
 isquoted:{[s]
-  // true if s is a double-quoted literal ("...").
+  / true if s is a double-quoted literal ("...").
   (1<count s) and all (first;last)@\:s="\""
   };
 
 firstunquoted:{[c;s]
-  // index of the first occurrence of char c in s that is OUTSIDE a double-quoted span, or count s
-  // if none. a running parity of quote characters marks whether each position is inside a string.
+  / index of the first occurrence of char c in s that is OUTSIDE a double-quoted span, or count s
+  / if none. a running parity of quote characters marks whether each position is inside a string.
   ?[;1b] (c=s) and not mod[;2] sums s="\""
   };
 
 stripcomment:{[l]
-  // drop a trailing # comment, but not a "#" that appears inside a "..." string.
+  / drop a trailing # comment, but not a "#" that appears inside a "..." string.
   (firstunquoted["#";l])#l
   };
 
 splitassign:{[l]
-  // split a line on its first unquoted "=" into (key;value), both trimmed. a line with no "=" is a
-  // malformed settings line - signal it (pure module: no logger to route through).
+  / split a line on its first unquoted "=" into (key;value), both trimmed. a line with no "=" is a
+  / malformed settings line - signal it (pure module: no logger to route through).
   eq:firstunquoted["=";l];
   if[count[l]=eq;'"di.toml: not a key = value line: ",l];
   trimstr each 0 1_'(0,eq)_l
   };
 
 unquotekey:{[k]
-  // strip surrounding double-quotes from a key if present; a bare key is returned unchanged.
+  / strip surrounding double-quotes from a key if present; a bare key is returned unchanged.
   $[isquoted k;1_-1_k;k]
   };
 
 unescape:{[s]
-  // expand the supported string escapes. applied as sequential replacements (\\ last); a literal
-  // backslash immediately followed by an escape char is an accepted edge (see toml.md).
+  / expand the supported string escapes. applied as sequential replacements (\\ last); a literal
+  / backslash immediately followed by an escape char is an accepted edge (see toml.md).
   ssr/[s;("\\\"";"\\n";"\\t";"\\\\");("\"";"\n";"\t";"\\")]
   };
 
 parsescalar:{[tok]
-  // parse one scalar token: a double-quoted string (unescaped, kept as a q string), true/false, a
-  // float (has a "."), else a long integer. an unquoted non-numeric token (a bare word, a datetime)
-  // parses to a null and is REJECTED - real strings must be quoted.
+  / parse one scalar token: a double-quoted string (unescaped, kept as a q string), true/false, a
+  / float (has a "."), else a long integer. an unquoted non-numeric token (a bare word, a datetime)
+  / parses to a null and is REJECTED - real strings must be quoted.
   tok:trimstr tok;
   if[isquoted tok;:unescape 1_-1_tok];
   if[tok~"true"; :1b];
@@ -80,14 +80,14 @@ parsescalar:{[tok]
   };
 
 splitcommas:{[s]
-  // split a "[...]" array's inner text on TOP-LEVEL commas (a comma inside a quoted element is not
-  // a separator). prepend a comma so the first element is captured by the same cut-and-drop rule.
+  / split a "[...]" array's inner text on TOP-LEVEL commas (a comma inside a quoted element is not
+  / a separator). prepend a comma so the first element is captured by the same cut-and-drop rule.
   1_'_[;s] where (s=",") and not mod[;2] sums "\""=s:",",s
   };
 
 parsevalue:{[v]
-  // parse a value: a "[...]" array into a list of scalars (empty array -> ()), an empty value into
-  // an empty string, anything else as a single scalar.
+  / parse a value: a "[...]" array into a list of scalars (empty array -> ()), an empty value into
+  / an empty string, anything else as a single scalar.
   v:trimstr v;
   if[0=count v;:""];
   if["["=first v;
@@ -97,24 +97,24 @@ parsevalue:{[v]
   };
 
 sectname:{[l]
-  // the section name from a "[name]" header line.
+  / the section name from a "[name]" header line.
   `$trimstr l 1+til -2+count l
   };
 
 addkv:{[d;k;v]
-  // add key k -> value v to dict d, SIGNALLING on a duplicate - a repeated key, a repeated section,
-  // or a key/section-name clash are all TOML errors and must not silently last-win. catenation (not
-  // ,: in-place) keeps the value list general, so mixing scalar / string / sub-dict / list values
-  // never hits a type-widen error.
+  / add key k -> value v to dict d, SIGNALLING on a duplicate - a repeated key, a repeated section,
+  / or a key/section-name clash are all TOML errors and must not silently last-win. catenation (not
+  / ,: in-place) keeps the value list general, so mixing scalar / string / sub-dict / list values
+  / never hits a type-widen error.
   if[k in key d;'"di.toml: duplicate key: ",string k];
   d,(enlist k)!enlist v
   };
 
 addline:{[acc;line]
-  // fold step over the settings lines. acc is (top; cursect; sect): the top-level dict, the current
-  // section name (` before any [section]), and the current section's accumulating dict. a [section]
-  // header flushes the open section into top and opens a fresh one; a key = value goes into the
-  // current section, or into top if no section is open yet. anything malformed signals.
+  / fold step over the settings lines. acc is (top; cursect; sect): the top-level dict, the current
+  / section name (` before any [section]), and the current section's accumulating dict. a [section]
+  / header flushes the open section into top and opens a fresh one; a key = value goes into the
+  / current section, or into top if no section is open yet. anything malformed signals.
   top:acc 0; cursect:acc 1; sect:acc 2;
   $[(first line)="[";
     [hdr:trimstr line;
@@ -136,10 +136,10 @@ addline:{[acc;line]
   };
 
 parsetoml:{[text]
-  // parse TOML text (a single string) into a dict; one level of [section] nesting (a section's dict
-  // is the value of its key). blank and comment-only lines contribute nothing. accepts a char string
-  // (or the char atom q makes of a 1-char literal, normalised to a string); any other type signals -
-  // without this a 1-char input is a char atom and ssr/vs throw a cryptic 'type.
+  / parse TOML text (a single string) into a dict; one level of [section] nesting (a section's dict
+  / is the value of its key). blank and comment-only lines contribute nothing. accepts a char string
+  / (or the char atom q makes of a 1-char literal, normalised to a string); any other type signals -
+  / without this a 1-char input is a char atom and ssr/vs throw a cryptic 'type.
   if[not 10h=abs type text;'"di.toml: parsetoml expects a char string; got type ",string type text];
   text:$[10h=type text;text;enlist text];
   lines:trimstr each stripcomment each "\n" vs text;
@@ -151,20 +151,20 @@ parsetoml:{[text]
   };
 
 parsefile:{[path]
-  // read and parse a .toml file into a dict. a MISSING file SIGNALS - di.toml fails loud so a caller
-  // that mistypes a path or loses a required file finds out immediately. a caller that treats a
-  // missing file as acceptable (a config cascade probing optional tiers) must guard existence ITSELF
-  // before calling, the way di.config does: if[0=count key hsym`$path;:()!()].
+  / read and parse a .toml file into a dict. a MISSING file SIGNALS - di.toml fails loud so a caller
+  / that mistypes a path or loses a required file finds out immediately. a caller that treats a
+  / missing file as acceptable (a config cascade probing optional tiers) must guard existence ITSELF
+  / before calling, the way di.config does: if[0=count key hsym`$path;:()!()].
   fsym:`$":",path;
   if[0=count key fsym;'"di.toml: file not found: ",path];
   parsetoml "\n" sv read0 fsym
   };
 
 getapimeta:{[]
-  // this module's api metadata, one row per CALLABLE API function, for di.torq to register with
-  // di.api. getapimeta itself is plumbing (di.torq calls it by convention) and is deliberately NOT
-  // listed - the registry describes the callable api, not plumbing. names are bare (di.torq qualifies).
+  / this module's api metadata, one row per CALLABLE API function, for di.torq to register with
+  / di.api. getapimeta itself is plumbing (di.torq calls it by convention) and is deliberately NOT
+  / listed - the registry describes the callable api, not plumbing. names are bare (di.torq qualifies).
   :flip `name`public`descrip`params`return!flip(
-    (`parsetoml; 1b; "parse TOML text into a dict (one level of [section] nesting)";               "[string: toml text]"; "dict: setting -> value (sections as sub-dicts)");
-    (`parsefile; 1b; "read and parse a .toml file into a dict (signals if the file is missing)";   "[string: file path]"; "dict: setting -> value"));
+    (`parsetoml; 1b; "parse TOML text into a dict (one level of section nesting)"; "[string: toml text]"; "dict: setting->value (sections nest)");
+    (`parsefile; 1b; "read and parse a .toml file into a dict (signals if missing)"; "[string: file path]"; "dict: setting->value"));
   };

--- a/di/toml/toml.q
+++ b/di/toml/toml.q
@@ -1,0 +1,170 @@
+// a small TOML parser for the modular torq world - scoped down for v1 to what real settings files
+// actually need: key = value pairs (bare or double-quoted keys), whole-line and trailing # comments
+// (quote-aware, so a "#" inside a string is not a comment), one level of [section] nesting (a
+// section becomes a sub-dict keyed by the section name), and scalar values - double-quoted strings
+// (\" \\ \n \t escapes), integers, floats, true/false, and flat arrays of any of those.
+// deliberately NOT supported: nested inline tables ({a=1,b=2}), dotted keys (a.b.c), single-quoted
+// literal strings, multi-line strings, datetimes, array-of-tables ([[section]]).
+// FAIL-LOUD by design (this is a SHARED utility used by many modules, not just di.config): anything
+// it cannot correctly parse SIGNALS a clear 'di.toml: ...' error rather than silently returning
+// nulls/garbage - a missing file, a line with no "=", an unparseable value (bare word / datetime),
+// an invalid bare key (a space/":"/etc. - i.e. most non-TOML lines that happen to contain "="), an
+// empty key, a dotted key, a duplicate key/section, and a malformed or array-of-tables section
+// header. **A caller that treats a missing file as acceptable
+// (a config cascade probing optional tiers) must guard existence ITSELF before calling** - the way
+// di.config does (if[0=count key hsym`$path;:()!()]); di.toml does not silently paper over it.
+// POLICY-FREE strings: every TOML string parses to a q char string (10h), NEVER a symbol (TOML has
+// no symbol type), so callers coerce with `$ at the point of use. integers parse to LONG (matching
+// what `value` gives a .q settings line), floats to float.
+// PURE module: no init, no logger, no injected deps - loaded during config resolution before any
+// logger exists, so it SIGNALS (does not log).
+// NOTE (reserved-word trap): q builtins cut/trim/parse/ss/sv/vs/ssr cannot be local names - helpers
+// are named trimstr/parsetoml/etc.; check `name in .Q.res before reusing a short name.
+
+// characters allowed in a bare (unquoted) key - anything else (a space, ":", etc.) must be
+// double-quoted, so a non-TOML line that happens to contain "=" fails loud instead of parsing to a
+// bogus symbol key.
+keychars:.Q.a,.Q.A,.Q.n,"_-";
+
+trimstr:{[s]
+  // trim leading/trailing whitespace, treating tabs as spaces.
+  trim ssr[s;"\t";" "]
+  };
+
+isquoted:{[s]
+  // true if s is a double-quoted literal ("...").
+  (1<count s) and all (first;last)@\:s="\""
+  };
+
+firstunquoted:{[c;s]
+  // index of the first occurrence of char c in s that is OUTSIDE a double-quoted span, or count s
+  // if none. a running parity of quote characters marks whether each position is inside a string.
+  ?[;1b] (c=s) and not mod[;2] sums s="\""
+  };
+
+stripcomment:{[l]
+  // drop a trailing # comment, but not a "#" that appears inside a "..." string.
+  (firstunquoted["#";l])#l
+  };
+
+splitassign:{[l]
+  // split a line on its first unquoted "=" into (key;value), both trimmed. a line with no "=" is a
+  // malformed settings line - signal it (pure module: no logger to route through).
+  eq:firstunquoted["=";l];
+  if[count[l]=eq;'"di.toml: not a key = value line: ",l];
+  trimstr each 0 1_'(0,eq)_l
+  };
+
+unquotekey:{[k]
+  // strip surrounding double-quotes from a key if present; a bare key is returned unchanged.
+  $[isquoted k;1_-1_k;k]
+  };
+
+unescape:{[s]
+  // expand the supported string escapes. applied as sequential replacements (\\ last); a literal
+  // backslash immediately followed by an escape char is an accepted edge (see toml.md).
+  ssr/[s;("\\\"";"\\n";"\\t";"\\\\");("\"";"\n";"\t";"\\")]
+  };
+
+parsescalar:{[tok]
+  // parse one scalar token: a double-quoted string (unescaped, kept as a q string), true/false, a
+  // float (has a "."), else a long integer. an unquoted non-numeric token (a bare word, a datetime)
+  // parses to a null and is REJECTED - real strings must be quoted.
+  tok:trimstr tok;
+  if[isquoted tok;:unescape 1_-1_tok];
+  if[tok~"true"; :1b];
+  if[tok~"false";:0b];
+  v:$[tok like "*.*";"F"$tok;"J"$tok];
+  if[null v;'"di.toml: unparseable value (quote strings; bare words/datetimes are out of scope): ",tok];
+  v
+  };
+
+splitcommas:{[s]
+  // split a "[...]" array's inner text on TOP-LEVEL commas (a comma inside a quoted element is not
+  // a separator). prepend a comma so the first element is captured by the same cut-and-drop rule.
+  1_'_[;s] where (s=",") and not mod[;2] sums "\""=s:",",s
+  };
+
+parsevalue:{[v]
+  // parse a value: a "[...]" array into a list of scalars (empty array -> ()), an empty value into
+  // an empty string, anything else as a single scalar.
+  v:trimstr v;
+  if[0=count v;:""];
+  if["["=first v;
+    inner:trimstr 1_-1_v;
+    :$[0=count inner;();parsescalar each splitcommas inner]];
+  parsescalar v
+  };
+
+sectname:{[l]
+  // the section name from a "[name]" header line.
+  `$trimstr l 1+til -2+count l
+  };
+
+addkv:{[d;k;v]
+  // add key k -> value v to dict d, SIGNALLING on a duplicate - a repeated key, a repeated section,
+  // or a key/section-name clash are all TOML errors and must not silently last-win. catenation (not
+  // ,: in-place) keeps the value list general, so mixing scalar / string / sub-dict / list values
+  // never hits a type-widen error.
+  if[k in key d;'"di.toml: duplicate key: ",string k];
+  d,(enlist k)!enlist v
+  };
+
+addline:{[acc;line]
+  // fold step over the settings lines. acc is (top; cursect; sect): the top-level dict, the current
+  // section name (` before any [section]), and the current section's accumulating dict. a [section]
+  // header flushes the open section into top and opens a fresh one; a key = value goes into the
+  // current section, or into top if no section is open yet. anything malformed signals.
+  top:acc 0; cursect:acc 1; sect:acc 2;
+  $[(first line)="[";
+    [hdr:trimstr line;
+     if[not "]"=last hdr;'"di.toml: malformed section header (missing ]): ",line];
+     if["[["~2 sublist hdr;'"di.toml: array-of-tables [[...]] is not supported: ",line];
+     nm:sectname line;
+     if[null nm;'"di.toml: empty section name: ",line];
+     if[not null cursect;top:addkv[top;cursect;sect]];
+     (top;nm;()!())];
+    [kv:splitassign line;
+     rawkey:kv 0;
+     if[0=count rawkey;'"di.toml: empty key: ",line];
+     if[not isquoted rawkey;
+       if["." in rawkey;'"di.toml: dotted keys are not supported (quote the key if the dot is literal): ",rawkey];
+       if[not all rawkey in keychars;'"di.toml: invalid bare key (only A-Za-z0-9_- allowed; quote the key otherwise): ",rawkey]];
+     k:`$unquotekey rawkey;
+     v:parsevalue kv 1;
+     $[null cursect;(addkv[top;k;v];cursect;sect);(top;cursect;addkv[sect;k;v])]]]
+  };
+
+parsetoml:{[text]
+  // parse TOML text (a single string) into a dict; one level of [section] nesting (a section's dict
+  // is the value of its key). blank and comment-only lines contribute nothing. accepts a char string
+  // (or the char atom q makes of a 1-char literal, normalised to a string); any other type signals -
+  // without this a 1-char input is a char atom and ssr/vs throw a cryptic 'type.
+  if[not 10h=abs type text;'"di.toml: parsetoml expects a char string; got type ",string type text];
+  text:$[10h=type text;text;enlist text];
+  lines:trimstr each stripcomment each "\n" vs text;
+  lines:lines where 0<count each lines;
+  acc:addline/[(()!();`;()!());lines];
+  top:acc 0;
+  if[not null acc 1;top:addkv[top;acc 1;acc 2]];
+  top
+  };
+
+parsefile:{[path]
+  // read and parse a .toml file into a dict. a MISSING file SIGNALS - di.toml fails loud so a caller
+  // that mistypes a path or loses a required file finds out immediately. a caller that treats a
+  // missing file as acceptable (a config cascade probing optional tiers) must guard existence ITSELF
+  // before calling, the way di.config does: if[0=count key hsym`$path;:()!()].
+  fsym:`$":",path;
+  if[0=count key fsym;'"di.toml: file not found: ",path];
+  parsetoml "\n" sv read0 fsym
+  };
+
+getapimeta:{[]
+  // this module's api metadata, one row per CALLABLE API function, for di.torq to register with
+  // di.api. getapimeta itself is plumbing (di.torq calls it by convention) and is deliberately NOT
+  // listed - the registry describes the callable api, not plumbing. names are bare (di.torq qualifies).
+  :flip `name`public`descrip`params`return!flip(
+    (`parsetoml; 1b; "parse TOML text into a dict (one level of [section] nesting)";               "[string: toml text]"; "dict: setting -> value (sections as sub-dicts)");
+    (`parsefile; 1b; "read and parse a .toml file into a dict (signals if the file is missing)";   "[string: file path]"; "dict: setting -> value"));
+  };


### PR DESCRIPTION
# di.toml — TorQ Modularisation PR

## Summary

Adds `di.toml`, a small, scoped-down TOML parser for the modular TorQ world. It reads settings
`.toml` files (and in-memory TOML text) into q dicts. It is a **general, standalone utility** — in
the POC it has two consumers: **di.config** (its `.toml` settings-cascade tier) and **di.depcheck**
(parsing `deps.toml` dependency manifests). It is a **pure** module — no `init`, no logger, no
injected dependencies — and **fail-loud**: any input it cannot correctly parse signals a clear
`'di.toml: …'` error rather than returning silent nulls/garbage.

---

## Background

The modular config layer (di.config) resolves a cascade over `.q` and `.toml` settings files. The
`.q` side is handled in-process; the `.toml` side needs a parser. TOML is not q, so this is a
hand-rolled, deliberately scoped parser covering exactly what real settings files use.

There is no TorQ original to extract here — TorQ has no TOML support. A `di.toml` exists in the
KDBX-POC, but per direction it was used only as a **scope guideline**; the implementation here was
written fresh against the kdbx-modules conventions and hardened well beyond the POC.

Because di.config invokes it *during config resolution — before any logger exists* — di.toml takes
no logger and cannot log; it signals instead. That also makes it trivially reusable by any other
module: `use`di.toml`, call `parsefile`/`parsetoml`, get a dict.

### Consumers (POC) — and why the design fits both

It was not built *for* one caller; it was built as a general parser, and its design choices are
exactly what both POC consumers need:

| Consumer | Use | What it relies on |
|---|---|---|
| **di.config** | `.toml` tier of the settings cascade | flat `key = value`, `[section]` sub-dicts, policy-free strings, guard-existence-before-calling |
| **di.depcheck** | `readdeps` parses each module's `deps.toml` | `` (use`di.toml)[`parsefile] `` → a dict with a `[dependencies]` **section** (a sub-dict); **quoted dotted keys** (`"di.servers" = "0.3.0"`) resolved to symbols; **string** version values kept as strings (never symbols) for `meetsmin` comparison |

The three choices that make depcheck work — one-level `[section]` → sub-dict, **quoted** dotted keys
accepted (unquoted dotted keys rejected as nesting), and policy-free string values — are all covered
and test-pinned (`fdeps` fixture: a real `deps.toml` shape → `` `di.servers`di.dbwrite!("0.3.0";"0.1.0") ``).

---

## Changes

### New files

| File | Description |
|---|---|
| `di/toml/toml.q` | Core implementation — `parsetoml`, `parsefile`, `getapimeta` and internal helpers |
| `di/toml/init.q` | Module entry point — loads `toml.q` and declares the export list |
| `di/toml/test.csv` | k4unit test suite (60 tests) |
| `di/toml/test.q` | Test fixtures — TOML text as q string literals + a temp-file helper |
| `di/toml/toml.md` | Module README |

### Differences from the KDBX-POC di.toml (guideline only)

| Aspect | POC di.toml | di.toml (this PR) |
|---|---|---|
| Integers | `"I"$` → int | `"J"$` → **long**, matching what `value` gives a `.q` settings line (`rows:100`) — avoids an int/long mismatch for consumers keying on the value's type |
| Bad input | silently returned nulls / odd symbols / partial garbage | **fail-loud** — every unparseable / unsupported / malformed case signals a clear `di.toml:` error |
| Missing file (`parsefile`) | returned `()!()` | **signals**; callers that treat missing as acceptable guard existence themselves (as di.config does) |
| Loop | `while` over lines | a `/` fold (`addline`) — no `while`, per the style guide |
| Dict build | in-place amend | catenation-based `addkv` (keeps the value list general; also signals on duplicate keys) |
| api metadata | `version` export | `getapimeta` (callable API only; no `version`/`VERSION` — deferred to di.depcheck) |

---

## Exported API

| Function | Signature | Description |
|---|---|---|
| `parsetoml` | `parsetoml[text]` | Parse a TOML string into a dict (one level of `[section]` nesting → sub-dicts). Accepts a string or a 1-char char-atom; any other type signals. |
| `parsefile` | `parsefile[path]` | Read and parse a `.toml` file into a dict. A **missing file signals** (see below). |
| `getapimeta` | `getapimeta[]` | Callable-API metadata rows for `di.torq` to register with `di.api` — `parsetoml`/`parsefile` only; framework plumbing (`getapimeta` itself) is deliberately not listed. |

Internal helpers (`trimstr`, `isquoted`, `instrmask`, `firstunquoted`, `stripcomment`, `splitassign`,
`unquotekey`, `parsekey`, `unescape`, `parsescalar`, `splitcommas`, `parsevalue`, `sectname`,
`addkv`, `addline`) and the `keychars` constant are not exported. A shared `instrmask`
(escape-aware in-string scan) backs both comment/`=` detection and array-comma splitting; a shared
`parsekey` validates keys and section names identically.

## TOML scope (v1)

**Supported:** `key = value` (bare or double-quoted keys); `#` comments (whole-line and trailing,
quote-aware); one level of `[section]` nesting; scalars — double-quoted strings (`\"` `\\` `\n` `\t`),
integers (→ long), floats, `true`/`false`, and flat arrays of any of those.

**Not supported (out of scope for settings):** nested inline tables, dotted keys, single-quoted
strings, multi-line strings, datetimes, array-of-tables.

**Type policy:** every TOML string → a q **char string** (never a symbol — TOML has no symbol type);
consumers coerce with `` `$ `` at the point of use. This is the contract di.config and its consumers
rely on.

## Fail-loud behaviour

di.toml signals (never silently mis-parses) on: a missing file; a line with no `=`; an unparseable
value (a bare word, a datetime); an **empty (missing) value** `k =`; an
**invalid bare key** (a space, `:`, or any char outside `A-Za-z0-9_-` — which makes most *non-TOML*
lines that happen to contain `=` fail loud); an empty key; a dotted key (an unquoted `a.b`; a
*quoted* `"a.b"` is a legitimate literal key); a duplicate key/section; an **unterminated / malformed
array**; an **unknown or dangling string escape** (`\x`, trailing `\`); and a malformed / empty /
array-of-tables section header. A non-char input is validated at the entry point so it can never
surface as a cryptic `'type`.

## Test coverage (60 k4unit tests — all pass)

### Areas covered

- **Scalars & types** — integer → long, float, bool, quoted string; policy-free strings stay `10h`.
- **Keys** — bare, double-quoted (with spaces), and `A-Za-z0-9_-` (dash/underscore) keys.
- **Comments** — whole-line, trailing, and a `#` inside a string (not a comment).
- **Sections** — one level of nesting → sub-dict; top-level keys before a section.
- **Arrays** — integer arrays (→ long vector), string arrays, empty arrays.
- **Escapes** — `\n` `\t` `\"` expanded.
- **Fail-loud** — no `=`, datetime, bare word, dotted key, `[[tables]]`, missing `]`, empty section,
  empty key, invalid bare key, duplicate key/section, non-TOML-with-`=` lines, non-char/`1-char`
  input.
- **`parsefile`** — reads a real file; signals on a missing file.
- **di.depcheck `deps.toml` contract** — a `[dependencies]` table of quoted dotted keys → version
  strings parses to the `symbol!string` dict `readdeps` expects (names are symbols, versions stay
  strings).
- **`getapimeta`** — documents exactly the callable exports; plumbing not registered; correct columns.

```
q)k4unit:use`di.k4unit
q)k4unit.moduletest`di.toml
… 60 test(s) …
All tests passed
```

Run from the repo root; `test.q` is loaded relatively. di.toml has no injected deps, so no mocks are
needed. (di.config is on a separate branch, so the end-to-end `.toml` cascade integration is verified
when the branches meet; standalone di.toml is green here.)

## Notes

- **Consumers must guard file existence.** Because `parsefile` fails loud on a missing file, a caller
  that treats "absent" as acceptable (a config cascade) checks existence first, as di.config does
  (`if[0=count key hsym`$path; :()!()]`). This is documented in the skill's di.toml section.
- **No known mis-parse gaps.** Escape handling is a correct single-pass unescaper, comment/`=`
  detection is escape-aware, and floats accept both `.` and `e`/`E` exponents. Anything outside the
  supported grammar (unsupported TOML constructs, underscored/hex numbers, etc.) is **rejected with a
  clear signal**, never silently mis-parsed. Scope is the settings-file subset by design.
- No `version` export / `VERSION` file yet — deferred to the coordinated di.depcheck rollout, as in
  di.config/di.servers.